### PR TITLE
Multi-Repo PR Creation

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -78,7 +78,7 @@ jobs:
         run: cd $GITHUB_WORKSPACE/cactus && git fetch origin $GITHUB_REF
 
       - name: Move Project to Target Ref
-        run: cd $GITHUB_WORKSPACE/cactus && && echo "Run $CHECKOUT_COMMAND" && eval $CHECKOUT_COMMAND
+        run: cd $GITHUB_WORKSPACE/cactus && echo "Run $CHECKOUT_COMMAND" && eval $CHECKOUT_COMMAND
 
       - name: Build Superpoms
         run: cd $GITHUB_WORKSPACE/telenav-superpom && mvn --no-transfer-progress --batch-mode install

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -74,7 +74,7 @@ jobs:
         run: cd $GITHUB_WORKSPACE/cactus && git fetch origin $GITHUB_REF
 
       - name: Move Project to Target Ref
-        run: cd $GITHUB_WORKSPACE/cactus && && echo "Run $CHECKOUT_COMMAND" && eval $CHECKOUT_COMMAND
+        run: cd $GITHUB_WORKSPACE/cactus && echo "Run $CHECKOUT_COMMAND" && eval $CHECKOUT_COMMAND
 
       - name: List Heads
         run: cd $GITHUB_WORKSPACE/cactus && find .git/refs/heads

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -74,7 +74,7 @@ jobs:
         run: cd $GITHUB_WORKSPACE/cactus && git fetch origin $GITHUB_REF
 
       - name: Move Project to Target Ref
-        run: cd $GITHUB_WORKSPACE/cactus && && echo "Run $CHECKOUT_COMMAND" && eval $CHECKOUT_COMMAND
+        run: cd $GITHUB_WORKSPACE/cactus && echo "Run $CHECKOUT_COMMAND" && eval $CHECKOUT_COMMAND
 
       - name: List Heads
         run: cd $GITHUB_WORKSPACE/cactus && find .git/refs/heads

--- a/cactus-cli/src/main/java/com/telenav/cactus/cli/CliCommand.java
+++ b/cactus-cli/src/main/java/com/telenav/cactus/cli/CliCommand.java
@@ -92,6 +92,17 @@ public abstract class CliCommand<T> implements Supplier<String>
     {
         return toString();
     }
+    
+    /**
+     * The result converter to actually use when running the process - this
+     * can be overridden to return a wrapper that can, say, detect an authentication
+     * failure, authenticate and then retry, or similar.
+     * 
+     * @return A converter
+     */
+    protected ProcessResultConverter<T> resultConverter() {
+        return resultCreator;
+    }
 
     public AwaitableCompletionStage<T> run()
     {
@@ -103,7 +114,7 @@ public abstract class CliCommand<T> implements Supplier<String>
                 return CompletableFuture.failedStage(
                         new IOException("Could not find executable for " + this));
             }
-            return resultCreator.onProcessStarted(this, p.get());
+            return resultConverter().onProcessStarted(this, p.get());
         });
     }
 

--- a/cactus-cli/src/main/java/com/telenav/cactus/cli/ProcessResultConverter.java
+++ b/cactus-cli/src/main/java/com/telenav/cactus/cli/ProcessResultConverter.java
@@ -54,6 +54,14 @@ public interface ProcessResultConverter<T>
     {
         return new BooleanProcessResultConverter(pred);
     }
+    
+    public static ProcessResultConverter<Integer> rawExitCode() {
+        return (description, proc) -> {
+            return AwaitableCompletionStage.of(proc.onExit().handle((p, thrown) -> {
+                return thrown != null ? -1 : p.exitValue();
+            }));
+        };
+    }
 
     default <R> ProcessResultConverter<R> map(Function<T, R> converter)
     {

--- a/cactus-cli/src/main/java/com/telenav/cactus/cli/ProcessResultConverter.java
+++ b/cactus-cli/src/main/java/com/telenav/cactus/cli/ProcessResultConverter.java
@@ -19,6 +19,7 @@
 package com.telenav.cactus.cli;
 
 import com.mastfrog.concurrent.future.AwaitableCompletionStage;
+import java.net.URI;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
 import java.util.function.Supplier;
@@ -61,6 +62,24 @@ public interface ProcessResultConverter<T>
                 return thrown != null ? -1 : p.exitValue();
             }));
         };
+    }
+    
+    public static ProcessResultConverter<URI> trailingUriAloneOnLine() {
+        return strings().map(processOutput -> {
+            String[] lines = processOutput.split("\n");
+            for (int i = lines.length - 1; i >= 0; i--)
+            {
+                String ln = lines[i].trim();
+                if (ln.startsWith("https://") && Character.isDigit(ln.charAt(ln
+                        .length() - 1)))
+                {
+                    return URI.create(ln);
+                }
+            }
+            throw new IllegalArgumentException(
+                    "No URI found in process output \n'"
+                    + processOutput + "'");
+        });
     }
 
     default <R> ProcessResultConverter<R> map(Function<T, R> converter)

--- a/cactus-cli/src/main/java/com/telenav/cactus/cli/ProcessResultConverter.java
+++ b/cactus-cli/src/main/java/com/telenav/cactus/cli/ProcessResultConverter.java
@@ -64,12 +64,13 @@ public interface ProcessResultConverter<T>
         };
     }
     
-    public static ProcessResultConverter<URI> trailingUriAloneOnLine() {
+    public static ProcessResultConverter<URI> trailingUriWithTrailingDigitAloneOnLine() {
         return strings().map(processOutput -> {
             String[] lines = processOutput.split("\n");
             for (int i = lines.length - 1; i >= 0; i--)
             {
                 String ln = lines[i].trim();
+                // A github pull request url ends in at least one digit
                 if (ln.startsWith("https://") && Character.isDigit(ln.charAt(ln
                         .length() - 1)))
                 {

--- a/cactus-cli/src/main/java/com/telenav/cactus/cli/StringProcessResultConverterImpl.java
+++ b/cactus-cli/src/main/java/com/telenav/cactus/cli/StringProcessResultConverterImpl.java
@@ -73,6 +73,7 @@ final class StringProcessResultConverterImpl implements
             });
             if (exitCodeTest.test(proc.exitValue()))
             {
+                stderr.done();
                 return stdout.done();
             }
             throw new ProcessFailedException(description, process, stdout.done(),

--- a/cactus-git/pom.xml
+++ b/cactus-git/pom.xml
@@ -26,7 +26,18 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>cactus-cli</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.13.3</version>
+            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.13.3</version>
+            <type>jar</type>
+        </dependency>
     </dependencies>
     
 </project>

--- a/cactus-git/pom.xml
+++ b/cactus-git/pom.xml
@@ -26,17 +26,18 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>cactus-cli</artifactId>
         </dependency>
+        
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.13.3</version>
-            <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.3</version>
-            <type>jar</type>
         </dependency>
     </dependencies>
     

--- a/cactus-git/src/main/java/com/telenav/cactus/git/GitCheckout.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/git/GitCheckout.java
@@ -961,7 +961,7 @@ public final class GitCheckout implements Comparable<GitCheckout>
         }
         arguments.add("--json");
         arguments.add(
-                "url,title,state,mergeable,body,number,mergeCommit,headRefName,baseRefName");
+                "url,title,state,mergeable,body,number,headRefName,baseRefName");
 
         return new GithubCommand<>(personalAcccessTokenSupplier,
                 strings().map(MinimalPRItem.parser()), root,

--- a/cactus-git/src/main/java/com/telenav/cactus/git/GitCheckout.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/git/GitCheckout.java
@@ -58,7 +58,7 @@ import static com.mastfrog.util.preconditions.Checks.notNull;
 import static com.telenav.cactus.cli.ProcessResultConverter.exitCode;
 import static com.telenav.cactus.cli.ProcessResultConverter.exitCodeIsZero;
 import static com.telenav.cactus.cli.ProcessResultConverter.strings;
-import static com.telenav.cactus.cli.ProcessResultConverter.trailingUriAloneOnLine;
+import static com.telenav.cactus.cli.ProcessResultConverter.trailingUriWithTrailingDigitAloneOnLine;
 
 /**
  * @author Tim Boudreau
@@ -905,7 +905,7 @@ public final class GitCheckout implements Comparable<GitCheckout>
         //
         // Use a timeout here, because `gh` has no non-interactive mode, and if it
         // is trying to ask a question, it will hang forever
-        return new GithubCommand<URI>(authenticationToken, trailingUriAloneOnLine(), root,
+        return new GithubCommand<URI>(authenticationToken, trailingUriWithTrailingDigitAloneOnLine(), root,
                 arguments.toArray(String[]::new)).run().awaitQuietly(Duration
                 .ofMinutes(2));
     }

--- a/cactus-git/src/main/java/com/telenav/cactus/git/GithubCommand.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/git/GithubCommand.java
@@ -15,18 +15,23 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 package com.telenav.cactus.git;
 
+import com.mastfrog.concurrent.future.AwaitableCompletionStage;
+import com.mastfrog.function.throwing.io.IOSupplier;
 import com.mastfrog.util.preconditions.Checks;
 import com.telenav.cactus.maven.log.BuildLog;
 import com.telenav.cactus.cli.CliCommand;
 import com.telenav.cactus.cli.ProcessResultConverter;
+import java.io.IOException;
+import java.io.PrintWriter;
 
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
 
 /**
  * @author Tim Boudreau
@@ -39,25 +44,47 @@ public class GithubCommand<T> extends CliCommand<T>
 
     private final String[] args;
 
-    private final BuildLog log = BuildLog.get()
-            .child(getClass().getSimpleName());
+    private final BuildLog log;
+    private final IOSupplier<String> accessTokenSupplier;
+    private RetryWithAuthProcessResultConverter<T> retryConverter;
 
     public GithubCommand(ProcessResultConverter<T> resultCreator, String... args)
     {
-        this(resultCreator, null, args);
+        this((IOSupplier<String>) null, resultCreator, null, args);
     }
 
-    public GithubCommand(ProcessResultConverter<T> resultCreator,
+    public GithubCommand(IOSupplier<String> authTokenSupplier,
+            ProcessResultConverter<T> resultCreator,
+            Path workingDir, String... args)
+    {
+        super("gh", resultCreator);
+        this.accessTokenSupplier = authTokenSupplier;
+        this.workingDir = workingDir;
+        this.args = Checks.notNull("args", args);
+        this.log = BuildLog.get()
+                .child(getClass().getSimpleName());
+    }
+
+    private GithubCommand(BuildLog log, ProcessResultConverter<T> resultCreator,
             Path workingDir, String... args)
     {
         super("gh", resultCreator);
         this.workingDir = workingDir;
         this.args = Checks.notNull("args", args);
+        this.log = log;
+        this.accessTokenSupplier = null;
     }
 
     public GithubCommand<T> withWorkingDir(Path dir)
     {
-        return new GithubCommand<>(resultCreator, dir, args);
+        return new GithubCommand<>(accessTokenSupplier, resultCreator, dir, args);
+    }
+
+    public GithubCommand<T> withAuthTokenSupplier(
+            IOSupplier<String> authTokenSupplier)
+    {
+        return new GithubCommand<>(authTokenSupplier, resultCreator, workingDir,
+                args);
     }
 
     @Override
@@ -88,5 +115,230 @@ public class GithubCommand<T> extends CliCommand<T>
     protected Optional<Path> workingDirectory()
     {
         return Optional.ofNullable(workingDir);
+    }
+
+    String accessToken() throws IOException
+    {
+        return accessTokenSupplier == null
+               ? null
+               : accessTokenSupplier.get();
+    }
+
+    @Override
+    protected synchronized ProcessResultConverter<T> resultConverter()
+    {
+        ProcessResultConverter<T> orig = super.resultConverter();
+        if (accessTokenSupplier != null && retryConverter == null)
+        {
+            // We need a single instance, because it is stateful - we need to
+            // detect if we're in a retry and not do so endlessly
+            retryConverter = new RetryWithAuthProcessResultConverter<>(this,
+                    orig);
+        }
+        return retryConverter == null || retryConverter.isInRetry()
+               ? orig
+               : retryConverter;
+    }
+
+    static class RetryWithAuthProcessResultConverter<T> implements
+            ProcessResultConverter<T>
+    {
+        private final ProcessResultConverter<T> orig;
+        private volatile boolean inRetry;
+        private final BuildLog childLog;
+        private final GithubCommand<T> cmd;
+
+        private RetryWithAuthProcessResultConverter(
+                GithubCommand<T> cmd,
+                ProcessResultConverter<T> orig)
+        {
+            this.orig = orig;
+            this.childLog = cmd.log.child(getClass().getSimpleName());
+            this.cmd = cmd;
+        }
+
+        boolean isInRetry()
+        {
+            return inRetry;
+        }
+
+        @Override
+        public AwaitableCompletionStage<T> onProcessStarted(
+                Supplier<String> description, Process process)
+        {
+            if (inRetry)
+            {
+                // Reentrancy - should not happen due to logic in resultConverter(),
+                // but under no circumstances should we loop endlessly through here.
+                childLog.debug("Retrying - delegate to " + orig);
+                return orig.onProcessStarted(description, process);
+            }
+            CompletableFuture<T> fut = new CompletableFuture<>();
+            childLog.debug(() -> "onProcessStarted");
+            process.onExit()
+                    .whenComplete((proc, thrown) ->
+                    {
+                        childLog.debug(
+                                () -> "Initial attempt exited with " + proc
+                                        .exitValue());
+                        if (thrown != null)
+                        {
+                            fut.completeExceptionally(thrown);
+                        }
+                        else
+                            if (proc.exitValue() == 4)
+                            {
+                                try
+                                {
+                                    authenticateAndRetry(fut);
+                                }
+                                catch (IOException ex)
+                                {
+                                    childLog.error("Reading auth info", ex);
+                                    fut.completeExceptionally(ex);
+                                }
+                            }
+                            else
+                            {
+                                forwardToOriginalConverter(description, process,
+                                        fut);
+                            }
+                    });
+            return AwaitableCompletionStage.of(fut);
+        }
+
+        private void forwardToOriginalConverter(Supplier<String> description,
+                Process process, CompletableFuture<T> futureReturnedToCaller)
+        {
+            childLog.debug(
+                    () -> "Forward to original");
+            AwaitableCompletionStage<T> innerFut = orig
+                    .onProcessStarted(description, process);
+            innerFut.whenComplete((res, thrown2) ->
+            {
+                if (thrown2 != null)
+                {
+                    futureReturnedToCaller.completeExceptionally(thrown2);
+                }
+                else
+                {
+                    futureReturnedToCaller.complete(res);
+                }
+            });
+        }
+
+        private void authenticateAndRetry(
+                CompletableFuture<T> futureReturnedToCaller) throws IOException
+        {
+            // gh returns an exit code of 4 if not authenticated
+            String accessToken = cmd.accessToken();
+            if (accessToken == null || accessToken.isBlank())
+            {
+                childLog.warn(
+                        "Access token provider returned null or blank token.");
+                futureReturnedToCaller.completeExceptionally(
+                        new RuntimeException(
+                                "Not authenticated, and access token not provided"));
+            }
+            else
+            {
+                childLog.info(
+                        "Not authenticated with GitHub - will authenticate and retry.");
+                Auth auth = new Auth(childLog.child("auth"),
+                        accessToken, cmd.workingDir);
+
+                auth.run().whenComplete((authSuccess, authThrown) ->
+                {
+                    onAfterAuthenticationAttempt(authThrown,
+                            futureReturnedToCaller, authSuccess);
+                });
+            }
+        }
+
+        private void onAfterAuthenticationAttempt(Throwable authThrown,
+                CompletableFuture<T> futureReturnedToCaller, Boolean authSuccess)
+        {
+            if (authThrown != null)
+            {
+                childLog.info(
+                        "Auth threw.  Original process exit code was " + 4,
+                        authThrown);
+                futureReturnedToCaller.completeExceptionally(authThrown);
+            }
+            else
+                if (authSuccess)
+                {
+                    inRetry = true;
+                    childLog.info(
+                            "Authentication was successful.  Retrying.");
+                    onAfterAuthenticationSucceeded(futureReturnedToCaller);
+                }
+                else
+                {
+                    futureReturnedToCaller.completeExceptionally(
+                            new RuntimeException(
+                                    "Authentication failed"));
+                }
+        }
+
+        private void onAfterAuthenticationSucceeded(
+                CompletableFuture<T> futureReturnedToCaller)
+        {
+            AwaitableCompletionStage<T> rerunStage = cmd.run();
+            rerunStage.whenComplete(
+                    (rerunResult, rerunThrown) ->
+            {
+                try
+                {
+                    if (rerunThrown != null)
+                    {
+                        childLog.info("Rerun threw ",
+                                rerunThrown);
+                        futureReturnedToCaller
+                                .completeExceptionally(rerunThrown);
+                    }
+                    else
+                    {
+                        childLog.debug(
+                                () -> "Rerun successful with " + rerunResult);
+                        futureReturnedToCaller.complete(rerunResult);
+                    }
+                }
+                finally
+                {
+                    // In theory, GithubCommand instances should never be reused, but
+                    // if one were, failing to clear this would result in a very difficult
+                    // to diagnose bug.
+                    inRetry = false;
+                }
+            });
+        }
+    }
+
+    private static class Auth extends GithubCommand<Boolean>
+    {
+        private final String accessToken;
+
+        Auth(BuildLog log, String accessToken, Path workingDir)
+        {
+            super(log, ProcessResultConverter.exitCodeIsZero(),
+                    workingDir,
+                    "auth",
+                    "login",
+                    "--hostname",
+                    "github.com",
+                    "--with-token");
+            this.accessToken = accessToken;
+        }
+
+        @Override
+        protected void onLaunch(Process process)
+        {
+            super.onLaunch(process);
+            try ( var out = new PrintWriter(process.getOutputStream()))
+            {
+                out.println(accessToken);
+            }
+        }
     }
 }

--- a/cactus-git/src/main/java/com/telenav/cactus/github/GithubCommand.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/github/GithubCommand.java
@@ -15,7 +15,7 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-package com.telenav.cactus.git;
+package com.telenav.cactus.github;
 
 import com.mastfrog.concurrent.future.AwaitableCompletionStage;
 import com.mastfrog.function.throwing.io.IOSupplier;

--- a/cactus-git/src/main/java/com/telenav/cactus/github/MergePullRequestOptions.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/github/MergePullRequestOptions.java
@@ -1,0 +1,30 @@
+package com.telenav.cactus.github;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+/**
+ * Options accepted by GitCheckout.mergePullRequest().
+ *
+ * @author Tim Boudreau
+ */
+public enum MergePullRequestOptions implements Consumer<List<String>>
+{
+    AUTO,
+    DELETE_BRANCH,
+    MERGE,
+    SQUASH,
+    REBASE;
+
+    @Override
+    public void accept(List<String> args)
+    {
+        args.add(toString());
+    }
+
+    @Override
+    public String toString()
+    {
+        return "--" + name().toLowerCase().replace('_', '-');
+    }
+}

--- a/cactus-git/src/main/java/com/telenav/cactus/github/MergePullRequestOptions.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/github/MergePullRequestOptions.java
@@ -14,7 +14,8 @@ public enum MergePullRequestOptions implements Consumer<List<String>>
     DELETE_BRANCH,
     MERGE,
     SQUASH,
-    REBASE;
+    REBASE,
+    ADMIN;
 
     @Override
     public void accept(List<String> args)

--- a/cactus-git/src/main/java/com/telenav/cactus/github/MinimalPRItem.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/github/MinimalPRItem.java
@@ -37,12 +37,12 @@ public class MinimalPRItem
     @JsonCreator
     public MinimalPRItem(
             @JsonProperty("baseRefName") String baseRefName,
-            @JsonProperty("body") String body,
+            @JsonProperty(value="body", required=false) String body,
             @JsonProperty("headRefName") String headRefName,
             @JsonProperty("mergeable") String mergeable,
             @JsonProperty("number") long number,
             @JsonProperty("state") String state,
-            @JsonProperty("title") String title,
+            @JsonProperty(value="title", required = false) String title,
             @JsonProperty("url") String url)
     {
         this.baseRefName = baseRefName;

--- a/cactus-git/src/main/java/com/telenav/cactus/github/MinimalPRItem.java
+++ b/cactus-git/src/main/java/com/telenav/cactus/github/MinimalPRItem.java
@@ -1,0 +1,130 @@
+package com.telenav.cactus.github;
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mastfrog.function.throwing.io.IOFunction;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+import static com.mastfrog.util.preconditions.Exceptions.chuck;
+import static java.util.Collections.emptyList;
+
+/**
+ * Pojo to represent the data we get back from a call to gh pr list with the
+ * argument
+ * <pre>
+ * --json url,title,state,mergeable,body,number,mergeCommit,headRefName,baseRefName
+ * </pre>
+ *
+ * @author Tim Boudreau
+ */
+public class MinimalPRItem
+{
+    public final String baseRefName;
+    public final String body;
+    public final String headRefName;
+    public final String mergeable;
+    public final long number;
+    public final String state;
+    public final String title;
+    public final String url;
+
+    @JsonCreator
+    public MinimalPRItem(
+            @JsonProperty("baseRefName") String baseRefName,
+            @JsonProperty("body") String body,
+            @JsonProperty("headRefName") String headRefName,
+            @JsonProperty("mergeable") String mergeable,
+            @JsonProperty("number") long number,
+            @JsonProperty("state") String state,
+            @JsonProperty("title") String title,
+            @JsonProperty("url") String url)
+    {
+        this.baseRefName = baseRefName;
+        this.body = body;
+        this.headRefName = headRefName;
+        this.mergeable = mergeable;
+        this.number = number;
+        this.state = state;
+        this.title = title;
+        this.url = url;
+    }
+
+    public URI toURI()
+    {
+        return URI.create(url);
+    }
+
+    public boolean isMergeable()
+    {
+        return "MERGEABLE".equals(mergeable);
+    }
+
+    public boolean isOpen()
+    {
+        return "OPEN".equals(state);
+    }
+
+    public static List<MinimalPRItem> parse(String output) throws IOException
+    {
+        if ("[]".equals(output.trim())) {
+            return emptyList();
+        }
+        return Arrays.asList(
+                new ObjectMapper().readValue(output, MinimalPRItem[].class));
+    }
+
+    public static Function<String, List<MinimalPRItem>> parser()
+    {
+        IOFunction<String, List<MinimalPRItem>> raw = MinimalPRItem::parse;
+        return raw.toNonThrowing();
+    }
+
+    @Override
+    public String toString()
+    {
+        try
+        {
+            return new ObjectMapper().writeValueAsString(this);
+        }
+        catch (JsonProcessingException ex)
+        {
+            return chuck(ex);
+        }
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 7;
+        hash = 73 * hash + Objects.hashCode(this.baseRefName);
+        hash = 73 * hash + Objects.hashCode(this.headRefName);
+        hash = 73 * hash + (int) (this.number ^ (this.number >>> 32));
+        hash = 73 * hash + Objects.hashCode(this.url);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        final MinimalPRItem other = (MinimalPRItem) obj;
+        if (this.number != other.number)
+            return false;
+        if (!Objects.equals(this.baseRefName, other.baseRefName))
+            return false;
+        if (!Objects.equals(this.headRefName, other.headRefName))
+            return false;
+        return Objects.equals(this.url, other.url);
+    }
+}

--- a/cactus-git/src/main/java/module-info.java
+++ b/cactus-git/src/main/java/module-info.java
@@ -22,5 +22,8 @@ open module cactus.git {
     requires cactus.util;
     requires com.mastfrog.function;
     requires com.mastfrog.preconditions;
+    requires com.fasterxml.jackson.annotation;
+    requires com.fasterxml.jackson.databind;
     exports com.telenav.cactus.git;
+    exports com.telenav.cactus.github;
 }

--- a/cactus-git/src/main/java/module-info.java
+++ b/cactus-git/src/main/java/module-info.java
@@ -22,8 +22,9 @@ open module cactus.git {
     requires cactus.util;
     requires com.mastfrog.function;
     requires com.mastfrog.preconditions;
-    requires com.fasterxml.jackson.annotation;
-    requires com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive com.fasterxml.jackson.databind;
+    requires transitive com.fasterxml.jackson.core;
     exports com.telenav.cactus.git;
     exports com.telenav.cactus.github;
 }

--- a/cactus-maven-log/src/main/java/com/telenav/cactus/maven/log/BuildLog.java
+++ b/cactus-maven-log/src/main/java/com/telenav/cactus/maven/log/BuildLog.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  *
  * @author Tim Boudreau
  */
-public class BuildLog
+public class BuildLog implements Consumer<String>
 {
 
     private static final ThreadLocal<BuildLog> LOG = new ThreadLocal<>();
@@ -58,6 +58,12 @@ public class BuildLog
         this(null, LoggerFactory.getLogger(context));
     }
 
+    @Override
+    public void accept(String t)
+    {
+        info(t);
+    }
+    
     public void ifDebug(Runnable run)
     {
         if (logger.isDebugEnabled())

--- a/cactus-maven-plugin/pom.xml
+++ b/cactus-maven-plugin/pom.xml
@@ -64,6 +64,10 @@
 
         <dependency>
             <groupId>com.mastfrog</groupId>
+            <artifactId>function</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.mastfrog</groupId>
             <artifactId>util-streams</artifactId>
         </dependency>
 
@@ -114,7 +118,7 @@
                 </configuration>
                 <version>${maven-compiler-plugin.version}</version>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
@@ -131,8 +135,8 @@
                     <goalPrefix>cactus</goalPrefix>
                 </configuration>
                 <executions>
-                    <!-- We need this for release, so that we can use compile, but 
-                         but not install, to pre-generate the plugin descriptor so that 
+                    <!-- We need this for release, so that we can use compile, but
+                         but not install, to pre-generate the plugin descriptor so that
                          the rest of the build, which will use this plugin from
                          target/classes, does not fail because there is no plugin.xml
                          in META-INF.  Harmless to do it earlier, since we're not using
@@ -145,7 +149,7 @@
                             <goal>descriptor</goal>
                         </goals>
                     </execution>
-                    
+
                     <execution>
                         <id>mojo-descriptor</id>
                         <phase>process-classes</phase>

--- a/cactus-maven-plugin/pom.xml
+++ b/cactus-maven-plugin/pom.xml
@@ -36,7 +36,7 @@
     </properties>
 
     <dependencies>
-
+        
         <!-- Cactus -->
 
         <dependency>
@@ -88,6 +88,9 @@
             <artifactId>maven-core</artifactId>
             <scope>provided</scope>
         </dependency>
+        
+        <!-- Testing -->
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -108,11 +111,13 @@
     <build>
         <plugins>
 
-            <plugin>
+            <!-- Keeping these in case we re-modularize -->
+            
+<!--            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
                     <compilerArgs>
-                        <arg>--add-reads</arg>
+                        <arg>- -add-reads</arg>
                         <arg>cactus.maven.plugin=ALL-UNNAMED</arg>
                     </compilerArgs>
                 </configuration>
@@ -123,9 +128,9 @@
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${maven-javadoc-plugin.version}</version>
                 <configuration>
-                    <additionalOptions>--add-reads cactus.maven.plugin=ALL-UNNAMED</additionalOptions>
+                    <additionalOptions>- -add-reads cactus.maven.plugin=ALL-UNNAMED</additionalOptions>
                 </configuration>
-            </plugin>
+            </plugin>-->
 
             <plugin>
 

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/AbstractGithubMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/AbstractGithubMojo.java
@@ -1,6 +1,8 @@
 package com.telenav.cactus.maven;
 
 import com.mastfrog.function.throwing.io.IOSupplier;
+import com.telenav.cactus.git.GitCheckout;
+import com.telenav.cactus.github.MinimalPRItem;
 import com.telenav.cactus.maven.log.BuildLog;
 import com.telenav.cactus.maven.mojobase.ScopedCheckoutsMojo;
 import com.telenav.cactus.maven.trigger.RunPolicy;
@@ -8,11 +10,21 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 
+import static com.mastfrog.util.preconditions.Checks.notNull;
 import static java.lang.System.getenv;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 
 /**
  * Base class for mojos which use the GitHub CLI which may require supplying an
@@ -23,8 +35,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 abstract class AbstractGithubMojo extends ScopedCheckoutsMojo
         implements IOSupplier<String>
 {
-    static final String GITHUB_CLI_PAT_ENV_VAR = "GITHUB_PAT";
-    static final String GITHUB_CLI_PAT_FILE_ENV_VAR = "GITHUB_PAT_FILE";
+    public static final String GITHUB_CLI_PAT_ENV_VAR = "CACTUS_GITHUB_PERSONAL_ACCESS_TOKEN";
+    public static final String GITHUB_CLI_PAT_FILE_ENV_VAR = "CACTUS_GITHUB_PERSONAL_ACCESS_TOKEN_FILE";
 
     /**
      * Github authentication token to use with the github cli client. If not
@@ -32,9 +44,19 @@ abstract class AbstractGithubMojo extends ScopedCheckoutsMojo
      * github personal access token, or the GITHUB_PAT_FILE environment variable
      * must be set to an extant file that contains the personal access token and
      * nothing else.
+     * <p>
+     * It is not <i>required</i> that an access token be available, but if none
+     * is, and authentication is required for a github operation, the build will
+     * fail at that point.
+     * </p>
      */
-    @Parameter(property = "cactus.authentication-token", required = false)
+    @Parameter(property = "cactus.github-personal-access-token",
+            required = false)
     private String authenticationToken;
+
+    // Cache the results of wire calls
+    private final Map<PullRequestListCacheKey, List<MinimalPRItem>> prListCache
+            = new ConcurrentHashMap<>();
 
     protected AbstractGithubMojo()
     {
@@ -49,7 +71,7 @@ abstract class AbstractGithubMojo extends ScopedCheckoutsMojo
     {
         super(policy);
     }
-    
+
     @Override
     protected final void onValidateParameters(BuildLog log, MavenProject project)
             throws Exception
@@ -63,9 +85,11 @@ abstract class AbstractGithubMojo extends ScopedCheckoutsMojo
             }
             if (result == null)
             {
-                fail("-Dcactus.authentication-token not passed, and neither "
+                log.warn(
+                        "-Dcactus.github-personal-access-token not passed, and neither "
                         + GITHUB_CLI_PAT_ENV_VAR + " nor " + GITHUB_CLI_PAT_FILE_ENV_VAR
-                        + " are set in the environment");
+                        + " are set in the environment.  If github calls need "
+                        + "authentication, they will fail.");
             }
         }
         onValidateGithubParameters(log, project);
@@ -89,27 +113,198 @@ abstract class AbstractGithubMojo extends ScopedCheckoutsMojo
 
     private String getTokenFromEnvironment() throws IOException
     {
+        // First try the environment variable that holds the PAT text
         String result = getenv(GITHUB_CLI_PAT_ENV_VAR);
         if (result == null)
         {
+            // If not present, look for the file path env var
             String filePath = getenv(GITHUB_CLI_PAT_FILE_ENV_VAR);
             if (filePath != null)
             {
-                Path file = Paths.get(filePath);
+                Path file = Paths.get(filePath.trim());
                 if (Files.exists(file))
                 {
-                    return Files.readString(file, UTF_8);
+                    return Files.readString(file, UTF_8).trim();
                 }
                 else
                 {
+                    // If it is set but does not exist, the operator needs
+                    // to fix that - fail hard.
                     throw new IOException(GITHUB_CLI_PAT_FILE_ENV_VAR
                             + " is set to " + filePath + " but it does not exist.");
                 }
             }
-            fail("-Dcactus.authentication-token not passed, and GH_TOKEN "
-                    + "environment variable is unset");
+        }
+        else
+        {
+            // Ensure if it was embedded in XML that we trim it down to
+            // what's needed
+            result = result.trim();
         }
         return result;
+    }
+
+    /**
+     * Get all pull requests using the passed branches.
+     *
+     * @param baseBranch The base branch the PR wants to be merged to - may be
+     * null to match PRs targeting any branch
+     * @param branchName The name of the PR's origin branch
+     * @param forCheckout The checkout / repository it belongs to
+     * @return A list of pull requests
+     */
+    protected final List<MinimalPRItem> pullRequestsForBranch(String baseBranch,
+            String branchName, GitCheckout forCheckout)
+    {
+        // We may trawl through pull requests multiple times, so ensure we only
+        // do one wire call per
+        PullRequestListCacheKey cacheKey = new PullRequestListCacheKey(
+                baseBranch,
+                forCheckout,
+                branchName);
+        // Use a cached list if present:
+        List<MinimalPRItem> result = prListCache.computeIfAbsent(cacheKey,
+                k -> forCheckout.listPullRequests(this,
+                        baseBranch, branchName, null));
+
+        // The caller prune unusable items, so return a copy
+        return new ArrayList<>(result);
+    }
+
+    /**
+     * In the case that the set of pull requests has been programmatically
+     * changed, dump any cached `gh pr list` results.
+     */
+    protected final void clearPRCache()
+    {
+        prListCache.clear();
+    }
+
+    /**
+     * Like <code>pullRequestsForBranch</code> but filters out any pull requests
+     * that whose state is not <code>OPEN</code> or whose mergeable status is
+     * not <code>MERGEABLE</code>.
+     *
+     * @param baseBranch The base branch (may be null to search any)
+     * @param branchName The terget branch
+     * @param forCheckout The checkout in question
+     * @return A list of pull requests
+     */
+    protected final List<MinimalPRItem> openAndMergeablePullRequestsForBranch(
+            String baseBranch, String branchName, GitCheckout forCheckout)
+    {
+        return filterNonOpenOrNotMergeable(log(), forCheckout,
+                pullRequestsForBranch(baseBranch, branchName, forCheckout));
+    }
+
+    /**
+     * Get the "lead" pull request for a branch - if there are zero pull
+     * requests for this branch combination, returns empty; if there is one,
+     * returns that; if more than once, the result is ambiguous and we have no
+     * way to disambiguate which pull request the user might want to operate on,
+     * so fail.
+     *
+     * @param baseBranch The base branch the PR wants to merge to (optional)
+     * @param branchName The branch the PR is on
+     * @param forCheckout The checkout in question
+     * @return A record of a PR if one exists
+     */
+    protected final Optional<MinimalPRItem> leadPullRequestForBranch(
+            String baseBranch,
+            String branchName,
+            GitCheckout forCheckout)
+    {
+        // Find a PR for the given branch name in the given checkout
+        List<MinimalPRItem> items = openAndMergeablePullRequestsForBranch(
+                baseBranch, branchName, forCheckout);
+        switch (items.size())
+        {
+            case 0:
+                // Okay, nothing here - that may be fine
+                return empty();
+            case 1:
+                // Exactly one PR associated with this branch - the ideal,
+                // unambiguous case
+                return of(items.get(0));
+            default:
+                // We do NOT pick a PR at random to merge and hope for the best.
+                return fail(
+                        "Ambiguous PRs - more than one PR on " + branchName + " in "
+                        + forCheckout.loggingName() + ": " + items);
+        }
+    }
+
+    private List<MinimalPRItem> filterNonOpenOrNotMergeable(BuildLog log,
+            GitCheckout in, List<MinimalPRItem> items)
+    {
+        // If the merge would fail, prune it out
+        for (Iterator<MinimalPRItem> it = items.iterator(); it.hasNext();)
+        {
+            MinimalPRItem i = it.next();
+            if (!i.isOpen() || !i.isMergeable())
+            {
+                log.warn(
+                        "Filter closed or not-mergeable from candidates for " + in
+                                .loggingName() + ": " + i);
+                it.remove();
+            }
+        }
+        return items;
+    }
+
+    private static final class PullRequestListCacheKey
+    {
+        private final Path checkoutPath;
+        private final String targetBranch;
+        private final String baseBranch;
+
+        private PullRequestListCacheKey(String baseBranch, GitCheckout checkout,
+                String branchName)
+        {
+            this.checkoutPath = notNull("checkout", checkout).checkoutRoot();
+            this.targetBranch = branchName;
+            this.baseBranch = baseBranch;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return checkoutPath.hashCode()
+                    + (71 * Objects.hashCode(targetBranch))
+                    + (263 * Objects.hashCode(baseBranch));
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (o == this)
+            {
+                return true;
+            }
+            else
+                if (o == null || o.getClass() != PullRequestListCacheKey.class)
+                {
+                    return false;
+                }
+            PullRequestListCacheKey key = (PullRequestListCacheKey) o;
+            return key.checkoutPath.toAbsolutePath().equals(checkoutPath
+                    .toAbsolutePath())
+                    && Objects.equals(baseBranch, key.baseBranch)
+                    && Objects.equals(targetBranch, key.targetBranch);
+        }
+
+        @Override
+        public String toString()
+        {
+            return checkoutPath.getFileName()
+                    + ":"
+                    + (targetBranch == null
+                       ? "<any>"
+                       : targetBranch)
+                    + "->" + (baseBranch == null
+                              ? "<any>"
+                              : baseBranch);
+        }
     }
 
 }

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/AbstractGithubMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/AbstractGithubMojo.java
@@ -1,0 +1,115 @@
+package com.telenav.cactus.maven;
+
+import com.mastfrog.function.throwing.io.IOSupplier;
+import com.telenav.cactus.maven.log.BuildLog;
+import com.telenav.cactus.maven.mojobase.ScopedCheckoutsMojo;
+import com.telenav.cactus.maven.trigger.RunPolicy;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import static java.lang.System.getenv;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ * Base class for mojos which use the GitHub CLI which may require supplying an
+ * authentication token.
+ *
+ * @author Tim Boudreau
+ */
+abstract class AbstractGithubMojo extends ScopedCheckoutsMojo
+        implements IOSupplier<String>
+{
+    static final String GITHUB_CLI_PAT_ENV_VAR = "GITHUB_PAT";
+    static final String GITHUB_CLI_PAT_FILE_ENV_VAR = "GITHUB_PAT_FILE";
+
+    /**
+     * Github authentication token to use with the github cli client. If not
+     * present, the GITHUB_PAT environment variable must be set to a valid
+     * github personal access token, or the GITHUB_PAT_FILE environment variable
+     * must be set to an extant file that contains the personal access token and
+     * nothing else.
+     */
+    @Parameter(property = "cactus.authentication-token", required = false)
+    private String authenticationToken;
+
+    protected AbstractGithubMojo()
+    {
+    }
+
+    protected AbstractGithubMojo(boolean runFirst)
+    {
+        super(runFirst);
+    }
+
+    protected AbstractGithubMojo(RunPolicy policy)
+    {
+        super(policy);
+    }
+    
+    @Override
+    protected final void onValidateParameters(BuildLog log, MavenProject project)
+            throws Exception
+    {
+        if (authenticationToken == null || authenticationToken.isBlank())
+        {
+            String result = getenv(GITHUB_CLI_PAT_ENV_VAR);
+            if (result == null)
+            {
+                result = getenv(GITHUB_CLI_PAT_FILE_ENV_VAR);
+            }
+            if (result == null)
+            {
+                fail("-Dcactus.authentication-token not passed, and neither "
+                        + GITHUB_CLI_PAT_ENV_VAR + " nor " + GITHUB_CLI_PAT_FILE_ENV_VAR
+                        + " are set in the environment");
+            }
+        }
+        onValidateGithubParameters(log, project);
+    }
+
+    protected void onValidateGithubParameters(BuildLog log, MavenProject project)
+            throws Exception
+    {
+        // do nothing - for subclasses
+    }
+
+    @Override
+    public final String get() throws IOException
+    {
+        if (authenticationToken == null || authenticationToken.isBlank())
+        {
+            return getTokenFromEnvironment();
+        }
+        return authenticationToken;
+    }
+
+    private String getTokenFromEnvironment() throws IOException
+    {
+        String result = getenv(GITHUB_CLI_PAT_ENV_VAR);
+        if (result == null)
+        {
+            String filePath = getenv(GITHUB_CLI_PAT_FILE_ENV_VAR);
+            if (filePath != null)
+            {
+                Path file = Paths.get(filePath);
+                if (Files.exists(file))
+                {
+                    return Files.readString(file, UTF_8);
+                }
+                else
+                {
+                    throw new IOException(GITHUB_CLI_PAT_FILE_ENV_VAR
+                            + " is set to " + filePath + " but it does not exist.");
+                }
+            }
+            fail("-Dcactus.authentication-token not passed, and GH_TOKEN "
+                    + "environment variable is unset");
+        }
+        return result;
+    }
+
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/BumpVersionMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/BumpVersionMojo.java
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 package com.telenav.cactus.maven;
 
+import com.telenav.cactus.maven.task.Rollback;
 import com.mastfrog.function.throwing.ThrowingRunnable;
 import com.telenav.cactus.git.Branches;
 import com.telenav.cactus.git.GitCheckout;

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/ClassloaderLog.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/ClassloaderLog.java
@@ -1,0 +1,135 @@
+package com.telenav.cactus.maven;
+
+import com.telenav.cactus.maven.mojobase.BaseMojo;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.classworlds.realm.ClassRealm;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+/**
+ *
+ * @author Tim Boudreau
+ */
+final class ClassloaderLog
+{
+
+    private static final boolean enabled = true;
+
+    static void log(MavenProject prj, BaseMojo mojo)
+    {
+        if (!enabled)
+        {
+            return;
+        }
+        try
+        {
+            _log(prj, mojo);
+        }
+        catch (Exception | Error e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    static void _log(MavenProject prj, BaseMojo mojo) throws Exception
+    {
+        final PluginDescriptor pluginDescriptor = (PluginDescriptor) mojo
+                .getPluginContext().get("pluginDescriptor");
+        ClassRealm classRealm = pluginDescriptor.getClassRealm();
+
+        logUrls(classRealm, prj);
+    }
+
+    private static void logPackages(ClassRealm classRealm, MavenProject prj)
+            throws IOException
+    {
+        List<String> pkgs = new ArrayList<>();
+        collectPackages(0, classRealm, prj, pkgs, new HashSet<>());
+        Collections.sort(pkgs);
+        StringBuilder sb = new StringBuilder();
+        for (String s : pkgs)
+        {
+            if (sb.length() > 0)
+            {
+                sb.append('\n');
+            }
+            sb.append(s);
+        }
+        sb.append('\n');
+        Path dest = Paths.get("/tmp").resolve(
+                prj.getArtifactId() + "-packages.txt");
+        Files.write(dest, sb.toString().getBytes(UTF_8),
+                StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.CREATE);
+    }
+
+    private static void collectPackages(int depth, ClassRealm classRealm,
+            MavenProject prj, List<String> pkgs, Set<ClassRealm> seen)
+            throws IOException
+    {
+        if (!seen.add(classRealm))
+        {
+            return;
+        }
+        for (Package p : classRealm.getDefinedPackages())
+        {
+            pkgs.add(p.toString());
+        }
+        for (ClassRealm cl : classRealm.getImportRealms())
+        {
+            collectPackages(depth + 1, cl, prj, pkgs, seen);
+        }
+
+    }
+
+    private static void logUrls(ClassRealm classRealm, MavenProject prj)
+            throws IOException
+    {
+        List<String> urls = new ArrayList<>();
+        StringBuilder sb = new StringBuilder();
+        for (URL url : classRealm.getURLs())
+        {
+            if (sb.length() > 0)
+            {
+                sb.append('\n');
+            }
+            sb.append(url);
+            urls.add(url.toString());
+        }
+        sb.append('\n');
+        Path dest = Paths.get("/tmp").resolve(prj.getArtifactId() + "-urls.txt");
+        Files.write(dest, sb.toString().getBytes(UTF_8),
+                StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.CREATE);
+
+        Collections.sort(urls);
+        sb.setLength(0);
+        for (String u : urls)
+        {
+            if (sb.length() > 0)
+            {
+                sb.append('\n');
+            }
+            sb.append(u);
+        }
+
+        sb.append('\n');
+        dest = Paths.get("/tmp").resolve(
+                prj.getArtifactId() + "-urls-sorted.txt");
+        Files.write(dest, sb.toString().getBytes(UTF_8),
+                StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING,
+                StandardOpenOption.CREATE);
+    }
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitMergePullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitMergePullRequestMojo.java
@@ -15,31 +15,49 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 package com.telenav.cactus.maven;
 
+import com.telenav.cactus.git.Branches;
 import com.telenav.cactus.git.GitCheckout;
+import com.telenav.cactus.github.MergePullRequestOptions;
+import com.telenav.cactus.github.MinimalPRItem;
 import com.telenav.cactus.maven.log.BuildLog;
 import com.telenav.cactus.maven.mojobase.BaseMojoGoal;
-import com.telenav.cactus.maven.mojobase.ScopedCheckoutsMojo;
 import com.telenav.cactus.maven.tree.ProjectTree;
+import com.telenav.cactus.maven.trigger.RunPolicies;
+import com.telenav.cactus.maven.trigger.RunPolicy;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.maven.plugin.MojoFailureException;
 
+import static com.telenav.cactus.github.MergePullRequestOptions.MERGE;
+import static com.telenav.cactus.github.MergePullRequestOptions.REBASE;
+import static java.util.Collections.emptyMap;
+import static java.util.EnumSet.noneOf;
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
 import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLETON;
 
 /**
- * Starts and finishes branches according to git flow branching conventions.
+ * Merges pull requests in all matching submodules, where the pull request's
+ * head branch matches the target branch - which is either passed explicitly, or
+ * is the branch the checkout owning the project Maven was invoked against is
+ * on.
  *
  * @author jonathanl (shibo)
  */
 @SuppressWarnings(
         {
-                "unused", "DuplicatedCode"
+            "unused", "DuplicatedCode"
         })
 @org.apache.maven.plugins.annotations.Mojo(
         defaultPhase = LifecyclePhase.VALIDATE,
@@ -47,38 +65,270 @@ import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLET
         instantiationStrategy = SINGLETON,
         name = "git-merge-pull-request", threadSafe = true)
 @BaseMojoGoal("git-merge-pull-request")
-public class GitMergePullRequestMojo extends ScopedCheckoutsMojo
+public class GitMergePullRequestMojo extends AbstractGithubMojo
 {
-    @Parameter(property = "cactus.authentication-token", required = true)
-    private String authenticationToken;
+    /**
+     * The name of the PR branch to merge. If set explicitly, it may be a branch
+     * of any of the matched checkouts. If unset, the branch of the checkout
+     * owning the project we are invoked against is used, and there <i>must</i>
+     * be a exactly one pull request extant for that branch which is open and
+     * mergable.
+     */
+    @Parameter(property = "cactus.target-branch")
+    private String targetBranch;
 
-    @Parameter(property = "cactus.branch-name", required = true)
-    private String branchName;
+    /**
+     * If true, pass <code>--auto</code> to `gh pr merge`.
+     */
+    @Parameter(property = "cactus.pr.auto", defaultValue = "true")
+    private boolean auto;
+
+    /**
+     * If true, pass <code>--delete-branch</code> to `gh pr merge`.
+     */
+    @Parameter(property = "cactus.pr.delete-branch", defaultValue = "false")
+    private boolean deleteBranch;
+
+    /**
+     * If true, pass <code>--merge</code> to `gh pr merge`. Mutually exclusive
+     * with the rebase option.
+     */
+    @Parameter(property = "cactus.pr.merge", defaultValue = "true")
+    private boolean merge;
+
+    /**
+     * If true, pass <code>--squash</code> to `gh pr merge`,
+     */
+    @Parameter(property = "cactus.pr.squash", defaultValue = "true")
+    private boolean squash;
+
+    /**
+     * If true, pass <code>--rebase</code> to `gh pr merge`. Mutually exclusive
+     * with the merge option.
+     */
+    @Parameter(property = "cactus.pr.rebase", defaultValue = "false")
+    private boolean rebase;
+
+    /**
+     * The base branch we intend the PR to be merged to - this is not passed to
+     * the client, but to weed out checkouts which are on it and therefore not
+     * likely to be part of the stuff to merge. The default is `develop`.
+     */
+    @Parameter(property = "cactus.base-branch", defaultValue = "develop")
+    private String baseBranch = "develop";
+
+    public GitMergePullRequestMojo()
+    {
+        super(RunPolicies.LAST);
+    }
+
+    @Override
+    protected void onValidateGithubParameters(BuildLog log, MavenProject project)
+            throws Exception
+    {
+        validateBranchName(targetBranch, true);
+        validateBranchName(baseBranch, false);
+        Set<MergePullRequestOptions> opts = options();
+        if (opts.contains(MERGE) && opts.contains(REBASE))
+        {
+            fail("MERGE and REBASE are mutually exclusive - pick one or the other. Have " + opts);
+        }
+    }
 
     @Override
     protected void execute(BuildLog log, MavenProject project,
-                           GitCheckout myCheckout,
-                           ProjectTree tree, List<GitCheckout> checkouts) throws Exception
+            GitCheckout myCheckout,
+            ProjectTree tree, List<GitCheckout> checkouts) throws Exception
     {
         if (checkouts.isEmpty())
         {
             log.info("No checkouts matched.");
             return;
         }
-
-        for (var checkout : checkouts)
+        String branch = targetBranch(myCheckout, tree);
+        if (branch.equals(baseBranch))
         {
-            checkout.mergePullRequest(authenticationToken, branchName);
+            fail("The target branch and the base branch are both '" + branch
+                    + "'.  There will not be any PRs from a branch to itself.");
+        }
+
+        Map<GitCheckout, MinimalPRItem> prForCheckout = findInitialPR(log,
+                branch, myCheckout, checkouts);
+        if (prForCheckout.isEmpty())
+        {
+            fail("No open and mergeable PRs found with the head branch '" + branch + "'");
+        }
+
+        collectPrsToMerge(log, branch, checkouts, prForCheckout);
+
+        Set<MergePullRequestOptions> options = options();
+
+        String logPrefix = isPretend()
+                           ? "(pretend) "
+                           : "";
+
+        log.info("Have " + prForCheckout.size() + " PRs to merge");
+
+        prForCheckout.forEach((checkout, pr) ->
+        {
+            log.info(logPrefix + "Merge PR " + pr.number + " for " + checkout
+                    .loggingName()
+                    + " on branch " + branch + " to " + pr.baseRefName + ": '" + pr.title + "'");
+            if (!isPretend())
+            {
+                checkout.mergePullRequest(this, pr.headRefName, options);
+            }
+        });
+    }
+
+    private void collectPrsToMerge(BuildLog log, String branchName,
+            List<GitCheckout> checkouts,
+            Map<? super GitCheckout, ? super MinimalPRItem> into)
+    {
+        // Collect the remainder of PRs associated with the branch name in
+        // question
+        for (GitCheckout co : checkouts)
+        {
+            // don't make a call over the wire twice if we already know the answer
+            if (!into.containsKey(co))
+            {
+                prItem(log, branchName, co)
+                        .ifPresent(item -> into.put(co, item));
+            }
         }
     }
 
-    @Override
-    protected void onValidateParameters(BuildLog log, MavenProject project)
-            throws Exception
+    private Map<GitCheckout, MinimalPRItem> findInitialPR(BuildLog log,
+            String branchName,
+            GitCheckout myCheckout,
+            List<GitCheckout> checkouts)
     {
-        if (authenticationToken.isBlank())
+        // Finds the first PR associated with the branch being targeted
+        // (either explicitly set, or the branch of the checkout of the invoking
+        // project).  If it is not explicitly set, one such must exist ofr the
+        // invoking project.  If it was, then it can be in any project, and the
+        // invoking project may not even be involved in the pull request.
+        //
+        // We return this is a map we can then continue populating to minimize
+        // expensive over-the-wire calls, so we do not list PRs more than once
+        // per checkout.
+        if (targetBranch == null)
         {
-            throw new RuntimeException("Must supply github authentication token");
+            // We were not passed a branch name, so we *must* find a PR using the
+            // current branch of myCheckout as its head
+            Map<GitCheckout, MinimalPRItem> result = new LinkedHashMap<>(1);
+            prItem(log, branchName, myCheckout).ifPresent(pr -> result.put(
+                    myCheckout, pr));
+            return result;
         }
+        else
+        {
+            // Try our own checkout preferentially
+            Optional<MinimalPRItem> item = prItem(log, branchName, myCheckout);
+            // Okay, we may just be in the root project but looking for the
+            // named branch in other projects.
+            if (!item.isPresent())
+            {
+                for (GitCheckout test : checkouts)
+                {
+                    if (!test.equals(myCheckout))
+                    {
+                        item = prItem(log, branchName, test);
+                        if (item.isPresent())
+                        {
+                            Map<GitCheckout, MinimalPRItem> result = new LinkedHashMap<>(
+                                    1);
+                            result.put(test, item.get());
+                            return result;
+                        }
+                    }
+                }
+            }
+        }
+        return emptyMap();
+    }
+
+    private String targetBranch(GitCheckout myCheckout, ProjectTree tree) throws MojoFailureException
+    {
+        if (targetBranch != null && !targetBranch.isBlank())
+        {
+            // If explicitly set, use the value set
+            return targetBranch;
+        }
+        else
+        {
+            // If not explicitly set, we're looking for PRs whose head branch
+            // has the same name as the checkout we were invoked in
+            Branches myBranches = tree.branches(myCheckout);
+            return myBranches.currentBranch().orElseThrow(
+                    () -> new MojoFailureException(myCheckout.loggingName()
+                            + " is not on a branch - pass cactus.target-branch "
+                            + "or check out a branch and retry."))
+                    .name();
+        }
+    }
+
+    Optional<MinimalPRItem> prItem(BuildLog log, String branchName,
+            GitCheckout forCheckout)
+    {
+        // Find a PR for the given branch name in the given checkout
+        List<MinimalPRItem> items = filterNonOpenOrNotMergeable(log, forCheckout,
+                forCheckout.listPullRequests(this,
+                        baseBranch, branchName, null));
+        switch (items.size())
+        {
+            case 0:
+                // Okay, nothing here - that may be fine
+                return empty();
+            case 1:
+                // Exactly one PR associated with this branch - the ideal,
+                // unambiguous case
+                return of(items.get(0));
+            default:
+                // We do NOT pick a PR at random to merge and hope for the best.
+                return fail(
+                        "Ambiguous PRs - more than one PR on " + branchName + " in " + forCheckout
+                                .loggingName()
+                        + ": " + items);
+        }
+    }
+
+    private List<MinimalPRItem> filterNonOpenOrNotMergeable(BuildLog log,
+            GitCheckout in, List<MinimalPRItem> items)
+    {
+        // If the merge would fail, prune it out
+        for (Iterator<MinimalPRItem> it = items.iterator(); it.hasNext();)
+        {
+            MinimalPRItem i = it.next();
+            if (!i.isOpen() || !i.isMergeable())
+            {
+                log.warn(
+                        "Filter closed or not-mergeable from candidates for " + in
+                                .loggingName() + ": " + i);
+                it.remove();
+            }
+        }
+        return items;
+    }
+
+    private Set<MergePullRequestOptions> options()
+    {
+        // Get the set of options based on the boolean properties of this mojo
+        Set<MergePullRequestOptions> result
+                = noneOf(MergePullRequestOptions.class);
+        boolean[] items =
+        {
+            auto, deleteBranch, merge, squash, rebase
+        };
+
+        MergePullRequestOptions[] all = MergePullRequestOptions.values();
+        for (int i = 0; i < items.length; i++)
+        {
+            if (items[i])
+            {
+                result.add(all[i]);
+            }
+        }
+        return result;
     }
 }

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitMergePullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitMergePullRequestMojo.java
@@ -45,21 +45,15 @@ import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLET
         defaultPhase = LifecyclePhase.VALIDATE,
         requiresDependencyResolution = ResolutionScope.NONE,
         instantiationStrategy = SINGLETON,
-        name = "git-pull-request", threadSafe = true)
-@BaseMojoGoal("git-pull-request")
-public class GitPullRequestMojo extends ScopedCheckoutsMojo
+        name = "git-merge-pull-request", threadSafe = true)
+@BaseMojoGoal("git-merge-pull-request")
+public class GitMergePullRequestMojo extends ScopedCheckoutsMojo
 {
     @Parameter(property = "cactus.authentication-token", required = true)
     private String authenticationToken;
 
-    @Parameter(property = "cactus.title", required = true)
-    private String title;
-
-    @Parameter(property = "cactus.body", required = true)
-    private String body;
-
-    @Parameter(property = "cactus.reviewers", required = true)
-    private String reviewers;
+    @Parameter(property = "cactus.branch-name", required = true)
+    private String branchName;
 
     @Override
     protected void execute(BuildLog log, MavenProject project,
@@ -74,7 +68,7 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
 
         for (var checkout : checkouts)
         {
-            checkout.createPullRequest(authenticationToken, reviewers, title, body);
+            checkout.mergePullRequest(authenticationToken, branchName);
         }
     }
 
@@ -85,14 +79,6 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
         if (authenticationToken.isBlank())
         {
             throw new RuntimeException("Must supply github authentication token");
-        }
-        if (title.isBlank())
-        {
-            throw new RuntimeException("Must supply title");
-        }
-        if (body.isBlank())
-        {
-            throw new RuntimeException("Must supply body");
         }
     }
 }

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
@@ -50,6 +50,9 @@ import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLET
 @BaseMojoGoal("git-pull-request")
 public class GitPullRequestMojo extends ScopedCheckoutsMojo
 {
+    
+    private static final String GITHUB_CLI_TOKEN_ENV_VAR = "GH_TOKEN";
+    
     @Parameter(property = "cactus.authentication-token", required = false)
     private String authenticationToken;
 
@@ -79,16 +82,24 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
         }
     }
     
-    private String authenticationToken() {
-        if (authenticationToken == null || authenticationToken.isBlank()) {
-            String result = getenv("GH_TOKEN");
-            if (result == null || result.isBlank()) {
-                fail("-Dcactus.authentication-token not passed, and GH_TOKEN "
-                        + "environment variable is unset");
-            }
-            return result;
+    private String authenticationToken()
+    {
+        if (authenticationToken == null || authenticationToken.isBlank())
+        {
+            return getTokenFromEnvironment();
         }
         return authenticationToken;
+    }
+    
+    private String getTokenFromEnvironment()
+    {
+        String result = getenv(GITHUB_CLI_TOKEN_ENV_VAR);
+        if (result == null)
+        {
+            fail("-Dcactus.authentication-token not passed, and GH_TOKEN "
+                    + "environment variable is unset");
+        }
+        return result;
     }
 
     @Override
@@ -97,7 +108,8 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
     {
         if (authenticationToken.isBlank())
         {
-            fail("Must supply github authentication token");
+            // Will fail if not present
+            getTokenFromEnvironment();
         }
         if (title.isBlank())
         {

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
@@ -15,20 +15,29 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
 package com.telenav.cactus.maven;
 
+import com.mastfrog.util.strings.RandomStrings;
+import com.telenav.cactus.git.Branches;
+import com.telenav.cactus.git.Branches.Branch;
 import com.telenav.cactus.git.GitCheckout;
+import com.telenav.cactus.maven.commit.CommitMessage;
 import com.telenav.cactus.maven.log.BuildLog;
 import com.telenav.cactus.maven.mojobase.BaseMojoGoal;
 import com.telenav.cactus.maven.mojobase.ScopedCheckoutsMojo;
 import com.telenav.cactus.maven.tree.ProjectTree;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 
 import static java.lang.System.getenv;
 import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLETON;
@@ -40,7 +49,7 @@ import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLET
  */
 @SuppressWarnings(
         {
-                "unused", "DuplicatedCode"
+            "unused", "DuplicatedCode"
         })
 @org.apache.maven.plugins.annotations.Mojo(
         defaultPhase = LifecyclePhase.VALIDATE,
@@ -50,25 +59,62 @@ import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLET
 @BaseMojoGoal("git-pull-request")
 public class GitPullRequestMojo extends ScopedCheckoutsMojo
 {
-    
+
     private static final String GITHUB_CLI_TOKEN_ENV_VAR = "GH_TOKEN";
-    
+
+    /**
+     * Github authentication token to use with the github cli client. If not
+     * present, the GH_TOKEN environment variable must be set to a valid token.
+     */
     @Parameter(property = "cactus.authentication-token", required = false)
     private String authenticationToken;
 
+    /**
+     * The pull request title.
+     */
     @Parameter(property = "cactus.title", required = true)
     private String title;
 
+    /**
+     * The pull request body.
+     */
     @Parameter(property = "cactus.body", required = true)
     private String body;
 
-    @Parameter(property = "cactus.reviewers", required = true)
+    /**
+     * The reviewers to request.
+     */
+    @Parameter(property = "cactus.reviewers", defaultValue = "")
     private String reviewers;
+
+    /**
+     * If true (the default), generate commits in any repositories that are
+     * matched and contain modifications or untracked, unignored files.
+     */
+    @Parameter(property = "cactus.commit", defaultValue = "true")
+    private boolean commit;
+
+    /**
+     * The base branch which new feature-branches should be created from, and
+     * which, if createBranchesIfNeeded is false, should be used as the fallback
+     * branch to put checkouts on if the target branch does not exist.
+     */
+    @Parameter(property = "cactus.base-branch", defaultValue = "develop")
+    String baseBranch = "develop";
+
+    /**
+     * The branch from which the pull request should be created; if unset, the
+     * current branch in the checkout is used.
+     */
+    @Parameter(property = "cactus.target-branch")
+    String targetBranch;
+
+    private String searchNonce;
 
     @Override
     protected void execute(BuildLog log, MavenProject project,
-                           GitCheckout myCheckout,
-                           ProjectTree tree, List<GitCheckout> checkouts) throws Exception
+            GitCheckout myCheckout,
+            ProjectTree tree, List<GitCheckout> checkouts) throws Exception
     {
         if (checkouts.isEmpty())
         {
@@ -76,12 +122,426 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             return;
         }
 
-        for (var checkout : checkouts)
+        tree.branches(myCheckout).currentBranch().ifPresent(br ->
         {
-            checkout.createPullRequest(authenticationToken(), reviewers, title, body);
+            if (br.name().equals(targetBranch))
+            {
+                fail("Attempting to create a pull request targeting the branch "
+                        + targetBranch + ", but " + coordinatesOf(project) + "'s "
+                        + "checkout is already on that branch.  Either switch to "
+                        + "the branch you want to create a pull request from, or "
+                        + "run this mojo against a project in the right project family "
+                        + "which is in a checkout that is on the branch you want to "
+                        + "create the pull request from.");
+            }
+        });
+        // Run the logic with a winnowed-down set of git checkouts which are on a
+        // branch with the same name as the branch the target project is on, or if
+        // targetBranch was set, on a branch with that name
+        createPullRequest(log, project, myCheckout, tree,
+                filterToCheckoutsOnTargetBranch(log, myCheckout, tree, checkouts));
+    }
+
+    protected void createPullRequest(BuildLog log, MavenProject project,
+            GitCheckout myCheckout,
+            ProjectTree tree, Map<GitCheckout, Branch> sourceBranchForCheckout)
+            throws Exception
+    {
+        // Filtering may have found no checkouts with changes on the target branch
+        // at all, in which case, it's fine, but we're done.
+        if (sourceBranchForCheckout.isEmpty())
+        {
+            log.error("Nothing to do.");
+            return;
+        }
+
+        // We will build a set of tasks to perform in a specific order, so
+        // we can guarantee as much is possible that we do not, say, create
+        // a half-finished set of PRs because a commit or push failed AFTER
+        // we have already created some of them
+        List<Runnable> tasks = new ArrayList<>(sourceBranchForCheckout.size());
+
+        // Collect the set of checkouts that actually need a pull request
+        // performed on them into this set:
+        Set<GitCheckout> createPullRequestsIn = new LinkedHashSet<>();
+
+        // So we don't scare people in pretend mode
+        String logPrefix = isPretend()
+                           ? "(pretend) "
+                           : "";
+
+        // First add a task that will verify that a remote branch we want
+        // to make the target of the pull request actually exists for all of
+        // the repositories we're trying to create a PR in - this should always
+        // be the case, but since it can be explicitly set, it is possible
+        // for it to be garbage.
+        //
+        // We make a point of doing a git fetch --all ahead of making any
+        // determination, to ensure if the destination branch was created since
+        // the local checkout was cloned, we don't fail erronously because the
+        // local checkout doesn't know about it.
+        //
+        // The point of adding this first is to fail early, before we have
+        // committed or pushed anything if the actual PR creation cannot possibly
+        // succeed
+        tasks.add(() ->
+        {
+            log.info(
+                    "Verifying existence of " + baseBranch + ", the PR destination, for "
+                    + createPullRequestsIn.size() + " checkouts.");
+            // This set will be populated by the time this runs
+            createPullRequestsIn.forEach(co ->
+            {
+                // If the destination branch does not exist at all on github,
+                // we fail here before any destructive actions have been taken
+                log.info(logPrefix + "Fetch all in " + co.loggingName());
+                if (!isPretend())
+                {
+                    co.fetchAll();
+                }
+                Branches br = tree.branches(co);
+                if (!br.find(baseBranch, false).isPresent())
+                {
+                    fail("No branch named '" + baseBranch + "' in default remote of " + co
+                            .loggingName());
+                }
+            });
+        });
+        // Our fetches will potentially change any cached Branches instances, since
+        // the remote heads may have changed, and we will test against that to
+        // see if there are any commits we have that don't exist in the remote target
+        // branch.
+        tasks.add(tree::invalidateCache);
+
+        if (commit)
+        {
+            CommitMessage msg = new CommitMessage(getClass(), title).paragraph(
+                    body);
+            Set<GitCheckout> toPush = new LinkedHashSet<>();
+            try ( var sect = msg.section("Creating Commits In"))
+            {
+                sourceBranchForCheckout.forEach((co, branch) ->
+                {
+                    // See if we have changes to commit
+                    if (co.isDirty() || co.hasUntrackedFiles())
+                    {
+                        log.debug("Dirty or untracked files in {0}", co
+                                .loggingName());
+                        sect.bulletPoint(co.loggingName());
+                        tasks.add(() ->
+                        {
+                            log.info(logPrefix + "Add all in " + co
+                                    .loggingName());
+                            if (!isPretend())
+                            {
+                                co.addAll();
+                            }
+                            log.info(logPrefix + "Commit in " + co
+                                    .loggingName());
+                            if (!isPretend())
+                            {
+                                co.commit(msg.toString());
+                            }
+                        });
+                        // Ensure we only push if *all* of our commit operations
+                        // have succeeded, so we don't push partial patches and
+                        // leave stuff behind
+                        toPush.add(co);
+                        createPullRequestsIn.add(co);
+                    }
+                    else
+                        if (containsPullRequestReadyCommits(myCheckout, co,
+                                branch))
+                        {
+                            log.debug("Have pull-request-ready commits in {0}",
+                                    co.loggingName());
+                            createPullRequestsIn.add(co);
+                            // If our local branch does not exist yet, we will
+                            // need to create it on the remote before trying to
+                            // create a pull request involving it
+                            if (!tree.branches(co)
+                                    .hasRemoteForLocalOrLocalForRemote(
+                                            branch))
+                            {
+                                log.info("Will push to create branch " + branch
+                                        + " on remote.");
+                                sect.bulletPoint(myCheckout.loggingName()
+                                        + " (no commit, buut creating remote branch "
+                                        + branch + ")");
+                                toPush.add(co);
+                            }
+                            else
+                            {
+                                sect.bulletPoint(myCheckout.loggingName()
+                                        + " (not creating commit)");
+                            }
+                        }
+                        else
+                        {
+                            log.debug("No pull-request-ready commits in {0}", co
+                                    .loggingName());
+                        }
+                });
+            }
+            // Now add push tasks, so that it is impossible to push anything
+            // unless all of our commit tasks have already succeeded
+            if (!toPush.isEmpty())
+            {
+                log.debug("Will push " + toPush);
+                tasks.add(() ->
+                {
+                    toPush.forEach(co ->
+                    {
+                        // The remote branch for our feature branch may not exist
+                        // yet, so figure out if we need the push to create it
+                        // or not.
+                        Branches theBranches = tree.branches(co);
+                        Branch src = sourceBranchForCheckout.get(co);
+                        assert src != null;
+                        // If there is no remote, we need, e.g.
+                        // `git push -u origin someLocalBranch`
+                        boolean needCreateBranch
+                                = !theBranches
+                                        .hasRemoteForLocalOrLocalForRemote(src);
+                        // Log exactly what we're going to do for clarity
+                        if (needCreateBranch)
+                        {
+                            log.info(logPrefix + "Push " + co.loggingName()
+                                    + " creating remote branch " + src);
+                        }
+                        else
+                        {
+                            log.info(logPrefix + "Push " + co.loggingName());
+                        }
+                        if (!isPretend())
+                        {
+                            if (needCreateBranch)
+                            {
+                                co.pushCreatingBranch();
+                            }
+                            else
+                            {
+                                co.push();
+                            }
+                        }
+                    });
+                });
+                tasks.add(tree::invalidateCache);
+            }
+            // Provide a smidegn of searchable, unique text that can be
+            // used to search on github and find the entire set of related
+            // pull requests
+            msg.paragraph("SearchNonce: " + searchNonce());
+        }
+        else
+        {
+            // If we are not committing anything, then just scan to find any
+            // commits that exist locally but not remotely in the destination
+            // branch, and if so, include it in our pull request set
+            sourceBranchForCheckout.forEach((co, branch) ->
+            {
+                if (containsPullRequestReadyCommits(myCheckout, co, branch))
+                {
+                    log.debug(
+                            "Have commits for pr in " + co.loggingName() + " on " + branch);
+                    createPullRequestsIn.add(co);
+
+                    // Creating the pr will fail if the branch doesn't exist
+                    // remotely, so add a push task to create it before we do
+                    // the PR if we need to.
+                    Branches theBranches = tree.branches(co);
+                    boolean needCreateBranch
+                            = !theBranches
+                                    .hasRemoteForLocalOrLocalForRemote(branch);
+                    if (needCreateBranch)
+                    {
+                        tasks.add(() ->
+                        {
+                            log.info("Will push " + co.loggingName()
+                                    + " to create remote branch for " + branch);
+                            if (!isPretend())
+                            {
+                                co.pushCreatingBranch();
+                            }
+                        });
+                    }
+                }
+            });
+        }
+        // If this set is empty, then we don't actually have any changes
+        // to create a pull request from
+        if (createPullRequestsIn.isEmpty())
+        {
+            log.warn(
+                    logPrefix + "No matched checkouts which are on the target branch and"
+                    + "which contain commits that do not already exist remotely.");
+        }
+        else
+        {
+            String token = authenticationToken();
+            // Now add a task for each checkout to the list which will actually
+            // create the PR
+            createPullRequestsIn.forEach(checkout ->
+            {
+                tasks.add(() ->
+                {
+                    // We will pass the origin and destination branches to the
+                    // github cli to ensure we create from what we think we are
+                    Branch sourceBranch = sourceBranchForCheckout.get(checkout);
+                    assert sourceBranch != null;
+
+                    log.info(logPrefix + "Create pull request for "
+                            + checkout.loggingName() + " from " + sourceBranch
+                            .name()
+                            + " to " + targetBranch);
+                    if (!isPretend())
+                    {
+                        // Really create the pull request.
+                        // We include the search nonce in the tail of the
+                        // body text, so that there is a unique, searchable
+                        // string to find the entire set of pull requests
+                        // created by this run
+                        checkout.createPullRequest(
+                                token,
+                                reviewers,
+                                title,
+                                body + "\n" + "SearchNonce: " + searchNonce() + "\n",
+                                sourceBranch.name(),
+                                targetBranch);
+                    }
+                });
+            });
+            // Make sure branch info is cleared for any mojo that might use
+            // the ProjectTree subsequently
+            tasks.add(tree::invalidateCache);
+            tasks.forEach(Runnable::run);
+        }
+        // In an IDE, this mojo can hang around, so clear state
+        searchNonce = null;
+    }
+
+    private Map<GitCheckout, Branch> filterToCheckoutsOnTargetBranch(
+            BuildLog log, GitCheckout myCheckout, ProjectTree tree,
+            List<GitCheckout> checkouts)
+    {
+        // Prune out any git checkouts that are not on a branch with the
+        // right name, from the set that were matched against the family
+        // or whatever scope we're running under
+        Map<GitCheckout, Branch> result = new LinkedHashMap<>(checkouts.size());
+        checkouts.forEach(co
+                -> prSourceBranchFor(log, myCheckout, co, tree).ifPresent(
+                        sourceBranch -> result.put(co, sourceBranch)));
+        return result;
+    }
+
+    private boolean containsPullRequestReadyCommits(GitCheckout myCheckout,
+            GitCheckout co, Branch sourceBranchForThisCheckout)
+    {
+        // This will tell us if there are any differences at all, but not
+        // whether we are ahead or behind the remote head
+        if (co.isNotAtSameHeadAsBranch(baseBranch))
+        {
+            // Get the set of branches that contain the head
+            Branches containingCommit = co.branchesContainingCommit(co.head());
+            // If find() returns a Branch object, then the remote destination branch
+            // already contains the head commit we would be using for our pull request - so
+            // there are no changes to create a pull request for this checkout from
+            return !containingCommit.find(sourceBranchForThisCheckout.name(),
+                    false).isPresent();
+        }
+        return false;
+    }
+
+    private Optional<Branch> prSourceBranchFor(BuildLog log,
+            GitCheckout myCheckout,
+            GitCheckout checkout, ProjectTree tree)
+    {
+        Branches branches = tree.branches(checkout);
+        // If the branch was explicitly passed (perhaps along with a list of
+        // families, if we are in the project root), use that, and simply
+        // only return something for the case that the checkout is already
+        // on a branch with that name.
+        //
+        // Otherwise, what we want to look for is a branch with the same
+        // name as the current branch of the checkout containing the project
+        // maven was invoked against
+        if (targetBranch != null)
+        {
+            // We were specifically told what branch to use - use it 
+            // if present AND IF THE CHECKOUT IS CURRENTLY ON THAT BRANCH, or
+            // skip the repository for the pull request otherwise
+            return branches.currentBranch().flatMap(br ->
+            {
+                // Only return something if the explicitly specified target branch 
+                // is the same branch as that of the checkout we are deciding
+                // to include or not
+                if (targetBranch.equals(br.name()))
+                {
+                    return Optional.of(br);
+                }
+                return Optional.empty();
+            });
+        }
+        else
+        {
+            // Find out what branch the project we're RUNNING AGAINST is on,
+            // and create a PR only for other matched checkouts which are on
+            // a branch with the same name, so we create PRs from all branches
+            // in the matched checkouts which are on a branch named feature/foo,
+            // but do NOT create PRs for other checkouts which might contain
+            // unpushed commits, but are not on the branch we are using
+            Branches targetProjectBranches = tree.branches(myCheckout);
+            Optional<Branch> targetProjectsBranch
+                    = targetProjectBranches.currentBranch();
+
+            // The project we were run against is in detached-head state - we
+            // have to fail here, as there is no way to track down a feature-branch
+            // name to look for in other checkouts
+            if (!targetProjectsBranch.isPresent())
+            {
+                // This will throw and get us out of here
+                fail("Target project " + coordinatesOf(project())
+                        + " in " + project().getBasedir()
+                        + " is not on a branch.  It needs to be to match "
+                        + "same-named branches in other checkouts to "
+                        + "decide what to create the pull request from.");
+            }
+
+            Optional<Branch> current = branches.currentBranch();
+            if (!current.isPresent())
+            {
+                // If the checkout we are queried about is in detached head state, don't
+                // use it, but log a warning.
+                log.warn("Ignoring " + checkout.loggingName() + " for pull "
+                        + "request - it is not on any branch.");
+                return current;
+            }
+            if (!current.get().name().equals(targetProjectsBranch.get().name()))
+            {
+                // If the checkout we are queried about *is* on some branch, but
+                // not the right one, also ignore it and log that at level info:
+                log.info(
+                        "Ignoring matched checkout " + checkout.loggingName() + " for pull "
+                        + "request - because we are matching the branch "
+                        + current.get().name()
+                        + " but it is on the branch " + targetProjectsBranch
+                                .get().name());
+                return Optional.empty();
+            }
+            return current;
         }
     }
-    
+
+    private String searchNonce()
+    {
+        // Gets us a random string with a time component, which allows us
+        // to include 
+        return searchNonce == null
+               ? searchNonce = new RandomStrings().randomChars(12) + "-"
+                + Long.toString(System.currentTimeMillis() / 1000, 36)
+               : searchNonce;
+    }
+
     private String authenticationToken()
     {
         if (authenticationToken == null || authenticationToken.isBlank())
@@ -90,7 +550,7 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
         }
         return authenticationToken;
     }
-    
+
     private String getTokenFromEnvironment()
     {
         String result = getenv(GITHUB_CLI_TOKEN_ENV_VAR);
@@ -106,7 +566,7 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
     protected void onValidateParameters(BuildLog log, MavenProject project)
             throws Exception
     {
-        if (authenticationToken.isBlank())
+        if (authenticationToken == null || authenticationToken.isBlank())
         {
             // Will fail if not present
             getTokenFromEnvironment();

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
@@ -122,6 +122,7 @@ public class GitPullRequestMojo extends AbstractGithubMojo
     protected void onValidateGithubParameters(BuildLog log, MavenProject project)
             throws Exception
     {
+        ClassloaderLog._log(project, this);
         if (Objects.equals(baseBranch, targetBranch))
         {
             fail("Base branch and target branch are the same: " + targetBranch);

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
@@ -104,7 +104,7 @@ public class GitPullRequestMojo extends AbstractGithubMojo
     /**
      * If true, open a browser tab with each new pull request.
      */
-    @Parameter(property = "cactus.open", defaultValue = "false")
+    @Parameter(property = "cactus.open", defaultValue = "true")
     boolean open;
 
     private String searchNonce;
@@ -145,6 +145,7 @@ public class GitPullRequestMojo extends AbstractGithubMojo
         finally
         {
             searchNonce = null;
+            clearPRCache();
         }
     }
 
@@ -165,7 +166,7 @@ public class GitPullRequestMojo extends AbstractGithubMojo
         // we can guarantee as much is possible that we do not, say, create
         // a half-finished set of PRs because a commit or push failed AFTER
         // we have already created some of them
-        List<Runnable> tasks = new ArrayList<>(sourceBranchForCheckout.size());
+        List<Runnable> tasks = new ArrayList<>(sourceBranchForCheckout.size() * 3);
 
         // Collect the set of checkouts that actually need a pull request
         // performed on them into this set:

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/GitPullRequestMojo.java
@@ -26,6 +26,10 @@ import com.telenav.cactus.maven.log.BuildLog;
 import com.telenav.cactus.maven.mojobase.BaseMojoGoal;
 import com.telenav.cactus.maven.mojobase.ScopedCheckoutsMojo;
 import com.telenav.cactus.maven.tree.ProjectTree;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -40,6 +44,7 @@ import java.util.Optional;
 import java.util.Set;
 
 import static java.lang.System.getenv;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLETON;
 
 /**
@@ -48,52 +53,53 @@ import static org.apache.maven.plugins.annotations.InstantiationStrategy.SINGLET
  * @author jonathanl (shibo)
  */
 @SuppressWarnings(
-{
-"unused", "DuplicatedCode"
-})
+        {
+            "unused", "DuplicatedCode"
+        })
 @org.apache.maven.plugins.annotations.Mojo(
-defaultPhase = LifecyclePhase.VALIDATE,
-requiresDependencyResolution = ResolutionScope.NONE,
-instantiationStrategy = SINGLETON,
-name = "git-pull-request", threadSafe = true)
+        defaultPhase = LifecyclePhase.VALIDATE,
+        requiresDependencyResolution = ResolutionScope.NONE,
+        instantiationStrategy = SINGLETON,
+        name = "git-pull-request", threadSafe = true)
 @BaseMojoGoal("git-pull-request")
 public class GitPullRequestMojo extends ScopedCheckoutsMojo
 {
-    
-    private static final String GITHUB_CLI_TOKEN_ENV_VAR = "GH_TOKEN";
-    
+
+    private static final String GITHUB_CLI_PAT_ENV_VAR = "GITHUB_PAT";
+    private static final String GITHUB_CLI_PAT_FILE_ENV_VAR = "GITHUB_PAT_FILE";
+
     /**
      * Github authentication token to use with the github cli client. If not
      * present, the GH_TOKEN environment variable must be set to a valid token.
      */
     @Parameter(property = "cactus.authentication-token", required = false)
     private String authenticationToken;
-    
+
     /**
      * The pull request title.
      */
-    @Parameter(property = "cactus.title", required = true)
+    @Parameter(property = "cactus.title", required = false)
     private String title;
-    
+
     /**
      * The pull request body.
      */
-    @Parameter(property = "cactus.body", required = true)
+    @Parameter(property = "cactus.body", required = false)
     private String body;
-    
+
     /**
      * The reviewers to request.
      */
     @Parameter(property = "cactus.reviewers", defaultValue = "")
     private String reviewers;
-    
+
     /**
      * If true (the default), generate commits in any repositories that are
      * matched and contain modifications or untracked, unignored files.
      */
     @Parameter(property = "cactus.commit", defaultValue = "true")
     private boolean commit;
-    
+
     /**
      * The base branch which new feature-branches should be created from, and
      * which, if createBranchesIfNeeded is false, should be used as the fallback
@@ -101,51 +107,59 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
      */
     @Parameter(property = "cactus.base-branch", defaultValue = "develop")
     String baseBranch = "develop";
-    
+
     /**
      * The branch from which the pull request should be created; if unset, the
      * current branch in the checkout is used.
      */
     @Parameter(property = "cactus.target-branch")
     String targetBranch;
-    
+
     private String searchNonce;
-    
+
     @Override
     protected void execute(BuildLog log, MavenProject project,
-                           GitCheckout myCheckout,
-                           ProjectTree tree, List<GitCheckout> checkouts) throws Exception
+            GitCheckout myCheckout,
+            ProjectTree tree, List<GitCheckout> checkouts) throws Exception
     {
         if (checkouts.isEmpty())
         {
             log.info("No checkouts matched.");
             return;
         }
-        
+
         tree.branches(myCheckout).currentBranch().ifPresent(br ->
-                                                            {
-                                                                if (br.name().equals(targetBranch))
-                                                                {
-                                                                    fail("Attempting to create a pull request targeting the branch "
-                                                                         + targetBranch + ", but " + coordinatesOf(project) + "'s "
-                                                                         + "checkout is already on that branch.  Either switch to "
-                                                                         + "the branch you want to create a pull request from, or "
-                                                                         + "run this mojo against a project in the right project family "
-                                                                         + "which is in a checkout that is on the branch you want to "
-                                                                         + "create the pull request from.");
-                                                                }
-                                                            });
+        {
+            if (br.name().equals(targetBranch))
+            {
+                fail("Attempting to create a pull request targeting the branch "
+                        + targetBranch + ", but " + coordinatesOf(project) + "'s "
+                        + "checkout is already on that branch.  Either switch to "
+                        + "the branch you want to create a pull request from, or "
+                        + "run this mojo against a project in the right project family "
+                        + "which is in a checkout that is on the branch you want to "
+                        + "create the pull request from.");
+            }
+        });
         // Run the logic with a winnowed-down set of git checkouts which are on a
         // branch with the same name as the branch the target project is on, or if
         // targetBranch was set, on a branch with that name
-        createPullRequest(log, project, myCheckout, tree,
-                          filterToCheckoutsOnTargetBranch(log, myCheckout, tree, checkouts));
+        try
+        {
+            createPullRequest(log, project, myCheckout, tree,
+                    filterToCheckoutsOnTargetBranch(log, myCheckout, tree,
+                            checkouts));
+        }
+        finally
+        {
+            searchNonce = null;
+        }
     }
-    
+
     protected void createPullRequest(BuildLog log, MavenProject project,
-                                     GitCheckout myCheckout,
-                                     ProjectTree tree, Map<GitCheckout, Branch> sourceBranchForCheckout)
-    throws Exception
+            GitCheckout myCheckout,
+            ProjectTree tree, Map<GitCheckout, Branch> sourceBranchForCheckout)
+            throws Exception
     {
         // Filtering may have found no checkouts with changes on the target branch
         // at all, in which case, it's fine, but we're done.
@@ -154,22 +168,22 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             log.error("Nothing to do.");
             return;
         }
-        
+
         // We will build a set of tasks to perform in a specific order, so
         // we can guarantee as much is possible that we do not, say, create
         // a half-finished set of PRs because a commit or push failed AFTER
         // we have already created some of them
         List<Runnable> tasks = new ArrayList<>(sourceBranchForCheckout.size());
-        
+
         // Collect the set of checkouts that actually need a pull request
         // performed on them into this set:
         Set<GitCheckout> createPullRequestsIn = new LinkedHashSet<>();
-        
+
         // So we don't scare people in pretend mode
         String logPrefix = isPretend()
-        ? "(pretend) "
-        : "";
-        
+                           ? "(pretend) "
+                           : "";
+
         // First add a task that will verify that a remote branch we want
         // to make the target of the pull request actually exists for all of
         // the repositories we're trying to create a PR in - this should always
@@ -185,103 +199,103 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
         // committed or pushed anything if the actual PR creation cannot possibly
         // succeed
         tasks.add(() ->
-                  {
-                      log.info(
-                               "Verifying existence of " + baseBranch + ", the PR destination, for "
-                               + createPullRequestsIn.size() + " checkouts.");
-                      // This set will be populated by the time this runs
-                      createPullRequestsIn.forEach(co ->
-                                                   {
-                                                       // If the destination branch does not exist at all on github,
-                                                       // we fail here before any destructive actions have been taken
-                                                       log.info(logPrefix + "Fetch all in " + co.loggingName());
-                                                       if (!isPretend())
-                                                       {
-                                                           co.fetchAll();
-                                                       }
-                                                       Branches br = tree.branches(co);
-                                                       if (!br.find(baseBranch, false).isPresent())
-                                                       {
-                                                           fail("No branch named '" + baseBranch + "' in default remote of " + co
-                                                                .loggingName());
-                                                       }
-                                                   });
-                  });
+        {
+            log.info(
+                    "Verifying existence of " + baseBranch + ", the PR destination, for "
+                    + createPullRequestsIn.size() + " checkouts.");
+            // This set will be populated by the time this runs
+            createPullRequestsIn.forEach(co ->
+            {
+                // If the destination branch does not exist at all on github,
+                // we fail here before any destructive actions have been taken
+                log.info(logPrefix + "Fetch all in " + co.loggingName());
+                if (!isPretend())
+                {
+                    co.fetchAll();
+                }
+                Branches br = tree.branches(co);
+                if (!br.find(baseBranch, false).isPresent())
+                {
+                    fail("No branch named '" + baseBranch + "' in default remote of " + co
+                            .loggingName());
+                }
+            });
+        });
         // Our fetches will potentially change any cached Branches instances, since
         // the remote heads may have changed, and we will test against that to
         // see if there are any commits we have that don't exist in the remote target
         // branch.
         tasks.add(tree::invalidateCache);
-        
+
         if (commit)
         {
             CommitMessage msg = new CommitMessage(getClass(), title).paragraph(
-                                                                               body);
+                    body);
             Set<GitCheckout> toPush = new LinkedHashSet<>();
             try ( var sect = msg.section("Creating Commits In"))
             {
                 sourceBranchForCheckout.forEach((co, branch) ->
-                                                {
-                                                    // See if we have changes to commit
-                                                    if (co.isDirty() || co.hasUntrackedFiles())
-                                                    {
-                                                        log.debug("Dirty or untracked files in {0}", co
-                                                                  .loggingName());
-                                                        sect.bulletPoint(co.loggingName());
-                                                        tasks.add(() ->
-                                                                  {
-                                                                      log.info(logPrefix + "Add all in " + co
-                                                                               .loggingName());
-                                                                      if (!isPretend())
-                                                                      {
-                                                                          co.addAll();
-                                                                      }
-                                                                      log.info(logPrefix + "Commit in " + co
-                                                                               .loggingName());
-                                                                      if (!isPretend())
-                                                                      {
-                                                                          co.commit(msg.toString());
-                                                                      }
-                                                                  });
-                                                        // Ensure we only push if *all* of our commit operations
-                                                        // have succeeded, so we don't push partial patches and
-                                                        // leave stuff behind
-                                                        toPush.add(co);
-                                                        createPullRequestsIn.add(co);
-                                                    }
-                                                    else
-                                                        if (containsPullRequestReadyCommits(myCheckout, co,
-                                                                                            branch))
-                                                        {
-                                                            log.debug("Have pull-request-ready commits in {0}",
-                                                                      co.loggingName());
-                                                            createPullRequestsIn.add(co);
-                                                            // If our local branch does not exist yet, we will
-                                                            // need to create it on the remote before trying to
-                                                            // create a pull request involving it
-                                                            if (!tree.branches(co)
-                                                                .hasRemoteForLocalOrLocalForRemote(
-                                                                                                   branch))
-                                                            {
-                                                                log.info("Will push to create branch " + branch
-                                                                         + " on remote.");
-                                                                sect.bulletPoint(myCheckout.loggingName()
-                                                                                 + " (no commit, buut creating remote branch "
-                                                                                 + branch + ")");
-                                                                toPush.add(co);
-                                                            }
-                                                            else
-                                                            {
-                                                                sect.bulletPoint(myCheckout.loggingName()
-                                                                                 + " (not creating commit)");
-                                                            }
-                                                        }
-                                                        else
-                                                        {
-                                                            log.debug("No pull-request-ready commits in {0}", co
-                                                                      .loggingName());
-                                                        }
-                                                });
+                {
+                    // See if we have changes to commit
+                    if (co.isDirty() || co.hasUntrackedFiles())
+                    {
+                        log.debug("Dirty or untracked files in {0}", co
+                                .loggingName());
+                        sect.bulletPoint(co.loggingName());
+                        tasks.add(() ->
+                        {
+                            log.info(logPrefix + "Add all in " + co
+                                    .loggingName());
+                            if (!isPretend())
+                            {
+                                co.addAll();
+                            }
+                            log.info(logPrefix + "Commit in " + co
+                                    .loggingName());
+                            if (!isPretend())
+                            {
+                                co.commit(msg.toString());
+                            }
+                        });
+                        // Ensure we only push if *all* of our commit operations
+                        // have succeeded, so we don't push partial patches and
+                        // leave stuff behind
+                        toPush.add(co);
+                        createPullRequestsIn.add(co);
+                    }
+                    else
+                        if (containsPullRequestReadyCommits(myCheckout, co,
+                                branch))
+                        {
+                            log.debug("Have pull-request-ready commits in {0}",
+                                    co.loggingName());
+                            createPullRequestsIn.add(co);
+                            // If our local branch does not exist yet, we will
+                            // need to create it on the remote before trying to
+                            // create a pull request involving it
+                            if (!tree.branches(co)
+                                    .hasRemoteForLocalOrLocalForRemote(
+                                            branch))
+                            {
+                                log.info("Will push to create branch " + branch
+                                        + " on remote.");
+                                sect.bulletPoint(myCheckout.loggingName()
+                                        + " (no commit, buut creating remote branch "
+                                        + branch + ")");
+                                toPush.add(co);
+                            }
+                            else
+                            {
+                                sect.bulletPoint(myCheckout.loggingName()
+                                        + " (not creating commit)");
+                            }
+                        }
+                        else
+                        {
+                            log.debug("No pull-request-ready commits in {0}", co
+                                    .loggingName());
+                        }
+                });
             }
             // Now add push tasks, so that it is impossible to push anything
             // unless all of our commit tasks have already succeeded
@@ -289,43 +303,43 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             {
                 log.debug("Will push " + toPush);
                 tasks.add(() ->
-                          {
-                              toPush.forEach(co ->
-                                             {
-                                                 // The remote branch for our feature branch may not exist
-                                                 // yet, so figure out if we need the push to create it
-                                                 // or not.
-                                                 Branches theBranches = tree.branches(co);
-                                                 Branch src = sourceBranchForCheckout.get(co);
-                                                 assert src != null;
-                                                 // If there is no remote, we need, e.g.
-                                                 // `git push -u origin someLocalBranch`
-                                                 boolean needCreateBranch
-                                                 = !theBranches
-                                                 .hasRemoteForLocalOrLocalForRemote(src);
-                                                 // Log exactly what we're going to do for clarity
-                                                 if (needCreateBranch)
-                                                 {
-                                                     log.info(logPrefix + "Push " + co.loggingName()
-                                                              + " creating remote branch " + src);
-                                                 }
-                                                 else
-                                                 {
-                                                     log.info(logPrefix + "Push " + co.loggingName());
-                                                 }
-                                                 if (!isPretend())
-                                                 {
-                                                     if (needCreateBranch)
-                                                     {
-                                                         co.pushCreatingBranch();
-                                                     }
-                                                     else
-                                                     {
-                                                         co.push();
-                                                     }
-                                                 }
-                                             });
-                          });
+                {
+                    toPush.forEach(co ->
+                    {
+                        // The remote branch for our feature branch may not exist
+                        // yet, so figure out if we need the push to create it
+                        // or not.
+                        Branches theBranches = tree.branches(co);
+                        Branch src = sourceBranchForCheckout.get(co);
+                        assert src != null;
+                        // If there is no remote, we need, e.g.
+                        // `git push -u origin someLocalBranch`
+                        boolean needCreateBranch
+                                = !theBranches
+                                        .hasRemoteForLocalOrLocalForRemote(src);
+                        // Log exactly what we're going to do for clarity
+                        if (needCreateBranch)
+                        {
+                            log.info(logPrefix + "Push " + co.loggingName()
+                                    + " creating remote branch " + src);
+                        }
+                        else
+                        {
+                            log.info(logPrefix + "Push " + co.loggingName());
+                        }
+                        if (!isPretend())
+                        {
+                            if (needCreateBranch)
+                            {
+                                co.pushCreatingBranch();
+                            }
+                            else
+                            {
+                                co.push();
+                            }
+                        }
+                    });
+                });
                 tasks.add(tree::invalidateCache);
             }
             // Provide a smidegn of searchable, unique text that can be
@@ -339,103 +353,102 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             // commits that exist locally but not remotely in the destination
             // branch, and if so, include it in our pull request set
             sourceBranchForCheckout.forEach((co, branch) ->
-                                            {
-                                                if (containsPullRequestReadyCommits(myCheckout, co, branch))
-                                                {
-                                                    log.debug(
-                                                              "Have commits for pr in " + co.loggingName() + " on " + branch);
-                                                    createPullRequestsIn.add(co);
-                                                    
-                                                    // Creating the pr will fail if the branch doesn't exist
-                                                    // remotely, so add a push task to create it before we do
-                                                    // the PR if we need to.
-                                                    Branches theBranches = tree.branches(co);
-                                                    boolean needCreateBranch
-                                                    = !theBranches
-                                                    .hasRemoteForLocalOrLocalForRemote(branch);
-                                                    if (needCreateBranch)
-                                                    {
-                                                        tasks.add(() ->
-                                                                  {
-                                                                      log.info("Will push " + co.loggingName()
-                                                                               + " to create remote branch for " + branch);
-                                                                      if (!isPretend())
-                                                                      {
-                                                                          co.pushCreatingBranch();
-                                                                      }
-                                                                  });
-                                                    }
-                                                }
-                                            });
+            {
+                if (containsPullRequestReadyCommits(myCheckout, co, branch))
+                {
+                    log.debug(
+                            "Have commits for pr in " + co.loggingName() + " on " + branch);
+                    createPullRequestsIn.add(co);
+
+                    // Creating the pr will fail if the branch doesn't exist
+                    // remotely, so add a push task to create it before we do
+                    // the PR if we need to.
+                    Branches theBranches = tree.branches(co);
+                    boolean needCreateBranch
+                            = !theBranches
+                                    .hasRemoteForLocalOrLocalForRemote(branch);
+                    if (needCreateBranch)
+                    {
+                        tasks.add(() ->
+                        {
+                            log.info("Will push " + co.loggingName()
+                                    + " to create remote branch for " + branch);
+                            if (!isPretend())
+                            {
+                                co.pushCreatingBranch();
+                            }
+                        });
+                    }
+                }
+            });
         }
         // If this set is empty, then we don't actually have any changes
         // to create a pull request from
         if (createPullRequestsIn.isEmpty())
         {
             log.warn(
-                     logPrefix + "No matched checkouts which are on the target branch and"
-                     + "which contain commits that do not already exist remotely.");
+                    logPrefix + "No matched checkouts which are on the target branch and"
+                    + "which contain commits that do not already exist remotely.");
         }
         else
         {
             String token = authenticationToken();
             // Now add a task for each checkout to the list which will actually
             // create the PR
-            createPullRequestsIn.forEach(checkout ->
-                                         {
-                                             tasks.add(() ->
-                                                       {
-                                                           // We will pass the origin and destination branches to the
-                                                           // github cli to ensure we create from what we think we are
-                                                           Branch sourceBranch = sourceBranchForCheckout.get(checkout);
-                                                           assert sourceBranch != null;
-                                                           
-                                                           log.info(logPrefix + "Create pull request for "
-                                                                    + checkout.loggingName() + " from " + sourceBranch
-                                                                    .name()
-                                                                    + " to " + targetBranch);
-                                                           if (!isPretend())
-                                                           {
-                                                               // Really create the pull request.
-                                                               // We include the search nonce in the tail of the
-                                                               // body text, so that there is a unique, searchable
-                                                               // string to find the entire set of pull requests
-                                                               // created by this run
-                                                               checkout.createPullRequest(
-                                                                                          token,
-                                                                                          reviewers,
-                                                                                          title,
-                                                                                          body + "\n" + "SearchNonce: " + searchNonce() + "\n",
-                                                                                          sourceBranch.name(),
-                                                                                          targetBranch);
-                                                           }
-                                                       });
-                                         });
+            createPullRequestsIn.forEach(checkout -> tasks.add(() ->
+            {
+                // We will pass the origin and destination branches to the
+                // github cli to ensure we create from what we think we are
+                Branch sourceBranch = sourceBranchForCheckout.get(
+                        checkout);
+                assert sourceBranch != null;
+
+                log.info(logPrefix + "Create pull request for "
+                        + checkout.loggingName() + " from "
+                        + sourceBranch.name() + " to " + targetBranch);
+
+                if (!isPretend())
+                {
+                    // Really create the pull request.
+                    // We include the search nonce in the tail of the
+                    // body text, so that there is a unique, searchable
+                    // string to find the entire set of pull requests
+                    // created by this run
+                    checkout.createPullRequest(
+                            token,
+                            reviewers,
+                            title,
+                            body + "\n" + "SearchNonce: " + searchNonce() + "\n",
+                            sourceBranch.name(),
+                            targetBranch);
+                }
+            }));
             // Make sure branch info is cleared for any mojo that might use
             // the ProjectTree subsequently
             tasks.add(tree::invalidateCache);
+            // Actually do the things
             tasks.forEach(Runnable::run);
         }
         // In an IDE, this mojo can hang around, so clear state
         searchNonce = null;
     }
-    
+
     private Map<GitCheckout, Branch> filterToCheckoutsOnTargetBranch(
-                                                                     BuildLog log, GitCheckout myCheckout, ProjectTree tree,
-                                                                     List<GitCheckout> checkouts)
+            BuildLog log, GitCheckout myCheckout, ProjectTree tree,
+            List<GitCheckout> checkouts)
     {
         // Prune out any git checkouts that are not on a branch with the
         // right name, from the set that were matched against the family
         // or whatever scope we're running under
         Map<GitCheckout, Branch> result = new LinkedHashMap<>(checkouts.size());
         checkouts.forEach(co
-                          -> prSourceBranchFor(log, myCheckout, co, tree).ifPresent(
-                                                                                    sourceBranch -> result.put(co, sourceBranch)));
+                -> prSourceBranchFor(log, myCheckout, co, tree).ifPresent(
+                        sourceBranch -> result.put(co, sourceBranch)));
         return result;
     }
-    
+
     private boolean containsPullRequestReadyCommits(GitCheckout myCheckout,
-                                                    GitCheckout co, Branch sourceBranchForThisCheckout)
+            GitCheckout co, Branch sourceBranchForThisCheckout)
     {
         // This will tell us if there are any differences at all, but not
         // whether we are ahead or behind the remote head
@@ -447,14 +460,14 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             // already contains the head commit we would be using for our pull request - so
             // there are no changes to create a pull request for this checkout from
             return !containingCommit.find(sourceBranchForThisCheckout.name(),
-                                          false).isPresent();
+                    false).isPresent();
         }
         return false;
     }
-    
+
     private Optional<Branch> prSourceBranchFor(BuildLog log,
-                                               GitCheckout myCheckout,
-                                               GitCheckout checkout, ProjectTree tree)
+            GitCheckout myCheckout,
+            GitCheckout checkout, ProjectTree tree)
     {
         Branches branches = tree.branches(checkout);
         // If the branch was explicitly passed (perhaps along with a list of
@@ -471,16 +484,16 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             // if present AND IF THE CHECKOUT IS CURRENTLY ON THAT BRANCH, or
             // skip the repository for the pull request otherwise
             return branches.currentBranch().flatMap(br ->
-                                                    {
-                                                        // Only return something if the explicitly specified target branch 
-                                                        // is the same branch as that of the checkout we are deciding
-                                                        // to include or not
-                                                        if (targetBranch.equals(br.name()))
-                                                        {
-                                                            return Optional.of(br);
-                                                        }
-                                                        return Optional.empty();
-                                                    });
+            {
+                // Only return something if the explicitly specified target branch 
+                // is the same branch as that of the checkout we are deciding
+                // to include or not
+                if (targetBranch.equals(br.name()))
+                {
+                    return Optional.of(br);
+                }
+                return Optional.empty();
+            });
         }
         else
         {
@@ -492,8 +505,8 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             // unpushed commits, but are not on the branch we are using
             Branches targetProjectBranches = tree.branches(myCheckout);
             Optional<Branch> targetProjectsBranch
-            = targetProjectBranches.currentBranch();
-            
+                    = targetProjectBranches.currentBranch();
+
             // The project we were run against is in detached-head state - we
             // have to fail here, as there is no way to track down a feature-branch
             // name to look for in other checkouts
@@ -501,19 +514,19 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
             {
                 // This will throw and get us out of here
                 fail("Target project " + coordinatesOf(project())
-                     + " in " + project().getBasedir()
-                     + " is not on a branch.  It needs to be to match "
-                     + "same-named branches in other checkouts to "
-                     + "decide what to create the pull request from.");
+                        + " in " + project().getBasedir()
+                        + " is not on a branch.  It needs to be to match "
+                        + "same-named branches in other checkouts to "
+                        + "decide what to create the pull request from.");
             }
-            
+
             Optional<Branch> current = branches.currentBranch();
             if (!current.isPresent())
             {
                 // If the checkout we are queried about is in detached head state, don't
                 // use it, but log a warning.
                 log.warn("Ignoring " + checkout.loggingName() + " for pull "
-                         + "request - it is not on any branch.");
+                        + "request - it is not on any branch.");
                 return current;
             }
             if (!current.get().name().equals(targetProjectsBranch.get().name()))
@@ -521,28 +534,28 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
                 // If the checkout we are queried about *is* on some branch, but
                 // not the right one, also ignore it and log that at level info:
                 log.info(
-                         "Ignoring matched checkout " + checkout.loggingName() + " for pull "
-                         + "request - because we are matching the branch "
-                         + current.get().name()
-                         + " but it is on the branch " + targetProjectsBranch
-                         .get().name());
+                        "Ignoring matched checkout " + checkout.loggingName() + " for pull "
+                        + "request - because we are matching the branch "
+                        + current.get().name()
+                        + " but it is on the branch " + targetProjectsBranch
+                                .get().name());
                 return Optional.empty();
             }
             return current;
         }
     }
-    
+
     private String searchNonce()
     {
         // Gets us a random string with a time component, which allows us
         // to include 
         return searchNonce == null
-        ? searchNonce = new RandomStrings().randomChars(12) + "-"
-        + Long.toString(System.currentTimeMillis() / 1000, 36)
-        : searchNonce;
+               ? searchNonce = new RandomStrings().randomChars(12) + "-"
+                + Long.toString(System.currentTimeMillis() / 1000, 36)
+               : searchNonce;
     }
-    
-    private String authenticationToken()
+
+    private String authenticationToken() throws IOException
     {
         if (authenticationToken == null || authenticationToken.isBlank())
         {
@@ -550,34 +563,60 @@ public class GitPullRequestMojo extends ScopedCheckoutsMojo
         }
         return authenticationToken;
     }
-    
-    private String getTokenFromEnvironment()
+
+    private String getTokenFromEnvironment() throws IOException
     {
-        String result = getenv(GITHUB_CLI_TOKEN_ENV_VAR);
+        String result = getenv(GITHUB_CLI_PAT_ENV_VAR);
         if (result == null)
         {
+            String filePath = getenv(GITHUB_CLI_PAT_FILE_ENV_VAR);
+            if (filePath != null)
+            {
+                Path file = Paths.get(filePath);
+                if (Files.exists(file))
+                {
+                    return Files.readString(file, UTF_8);
+                }
+                else
+                {
+                    throw new IOException(GITHUB_CLI_PAT_FILE_ENV_VAR
+                            + " is set to " + filePath + " but it does not exist.");
+                }
+            }
             fail("-Dcactus.authentication-token not passed, and GH_TOKEN "
-                 + "environment variable is unset");
+                    + "environment variable is unset");
         }
         return result;
     }
-    
+
     @Override
     protected void onValidateParameters(BuildLog log, MavenProject project)
-    throws Exception
+            throws Exception
     {
         if (authenticationToken == null || authenticationToken.isBlank())
         {
-            // Will fail if not present
-            getTokenFromEnvironment();
+            String result = getenv(GITHUB_CLI_PAT_ENV_VAR);
+            if (result == null)
+            {
+                result = getenv(GITHUB_CLI_PAT_FILE_ENV_VAR);
+            }
+            if (result == null)
+            {
+                fail("-Dcactus.authentication-token not passed, and neither "
+                        + GITHUB_CLI_PAT_ENV_VAR + " nor " + GITHUB_CLI_PAT_FILE_ENV_VAR
+                        + " are set in the environment");
+            }
         }
-        if (title.isBlank())
+        if (title != null && title.isBlank())
         {
-            fail("Must supply title");
+            fail("title / cactus.title is empty");
         }
-        if (body.isBlank())
+        if (body != null && body.isBlank())
         {
-            fail("Must supply body");
+            fail("body / cactus.body is empty");
+        }
+        if ((title == null) != (body == null)) {
+            fail("Either title and body must both be set, or both unset.");
         }
     }
 }

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/mojobase/BaseMojo.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/mojobase/BaseMojo.java
@@ -301,11 +301,11 @@ public abstract class BaseMojo extends AbstractMojo
      * @param code The code to run
      * @throws Exception if something goes wrong
      */
-    protected void ifNotPretending(ThrowingRunnable code) throws Exception
+    protected void ifNotPretending(ThrowingRunnable code)
     {
         if (!pretend)
         {
-            code.run();
+            code.toNonThrowing().run();
         }
     }
 
@@ -702,8 +702,9 @@ public abstract class BaseMojo extends AbstractMojo
         return new MavenCoordinates(notNull("project", project).getGroupId(),
                 project.getArtifactId(), project.getVersion());
     }
-    
-    protected final Pom toPom(MavenProject project) {
+
+    protected final Pom toPom(MavenProject project)
+    {
         return Pom.from(project.getFile().toPath()).get();
     }
 }

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/Rollback.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/Rollback.java
@@ -1,4 +1,21 @@
-package com.telenav.cactus.maven;
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
 
 import com.mastfrog.function.optional.ThrowingOptional;
 import com.mastfrog.function.throwing.ThrowingRunnable;
@@ -55,7 +72,7 @@ public final class Rollback
             {
                 failure.addSuppressed(rollbackFailure);
             }
-            Exceptions.chuck(failure); // rethrows
+            return Exceptions.chuck(failure); // rethrows
         }
         return code;
     }

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/RollbackTaskImpl.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/RollbackTaskImpl.java
@@ -1,0 +1,66 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.function.throwing.ThrowingRunnable;
+import com.mastfrog.function.throwing.ThrowingSupplier;
+import java.util.function.Consumer;
+
+/**
+ * Implementation of Task which can produce a rollback runnable.
+ *
+ * @author Tim Boudreau
+ */
+final class RollbackTaskImpl implements Task
+{
+    final String name;
+    final ThrowingSupplier<ThrowingRunnable> run;
+
+    RollbackTaskImpl(String name, ThrowingSupplier<ThrowingRunnable> run)
+    {
+        this.name = name;
+        this.run = run;
+    }
+
+    @Override
+    public void accept(Consumer<String> log, Rollback rb) throws Exception
+    {
+        ThrowingRunnable rollbackWork = run.get();
+        if (rollbackWork != null)
+        {
+            rb.addRollbackTask(() ->
+            {
+                log.accept("Rollback " + name());
+                rollbackWork.run();
+            });
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return name();
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
+    }
+
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/Task.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/Task.java
@@ -1,0 +1,104 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.function.throwing.ThrowingBiConsumer;
+import java.util.Arrays;
+import java.util.function.Consumer;
+
+/**
+ * A named task which can be executed and logged; the work it performs is
+ * performed by the <code>accept</code> method of the inherited
+ * <code>ThrowingBiConsumer</code> interface, which takes a string consumer for
+ * emitting logging information, and a Rollback to which rollback tasks can be
+ * attached.
+ * <p>
+ * The framework's implementation of Task should usually be used - the one case
+ * for implementing Task directly is where you need to directly access the
+ * Rollback instance.
+ * </p>
+ *
+ * @author Tim Boudreau
+ */
+public interface Task extends ThrowingBiConsumer<Consumer<String>, Rollback>
+{
+    /**
+     * The name of this task, describing what it does or the category its child
+     * tasks are in.
+     *
+     * @return A name
+     */
+    String name();
+
+    /**
+     * Determine if this task has no work to do.
+     *
+     * @return True if this task has no work to do
+     */
+    default boolean isEmpty()
+    {
+        return false;
+    }
+
+    /**
+     * Convert this task into a markdown-style bullet list with appropriate
+     * indenting for nested tasks.
+     *
+     * @return A string
+     */
+    default String stringify()
+    {
+        return stringify(new StringBuilder()).toString();
+    }
+
+    /**
+     * Include this task in a markdown-style bullet list with appropriate
+     * indenting for nested tasks, in the passed StringBuilder.
+     *
+     * @param into The StringBuilder to append to
+     * @return A string
+     */
+    default StringBuilder stringify(StringBuilder into)
+    {
+        return stringify(0, into);
+    }
+
+    /**
+     * Include this task in a markdown-style bullet list with appropriate
+     * indenting for nested tasks, in the passed StringBuilder.
+     *
+     * @param depth The nesting depth at to indent this task to and the basis
+     * for indentingany child tasks
+     * @param into The StringBuilder to append to
+     * @return A string
+     */
+    default StringBuilder stringify(int depth, StringBuilder into)
+    {
+        // Format the task (and any children) as a markdown-like
+        // bulleted list
+        char[] c = new char[depth * 2];
+        Arrays.fill(c, ' ');
+        if (into.length() > 0 && into.charAt(into.length() - 1) != '\n')
+        {
+            into.append('\n');
+        }
+        into.append(c).append(" * ").append(name());
+        return into;
+    }
+
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskGroup.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskGroup.java
@@ -1,0 +1,123 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.function.throwing.ThrowingConsumer;
+import com.mastfrog.function.throwing.ThrowingRunnable;
+import com.mastfrog.function.throwing.ThrowingSupplier;
+
+/**
+ * A group of tasks which should be run in the order tasks were added to it.
+ *
+ * @author Tim Boudreau
+ */
+public interface TaskGroup extends Task, Iterable<Task>
+{
+    /**
+     * Add a task implementation.
+     *
+     * @param task A task
+     * @return this
+     */
+    TaskGroup add(Task task);
+
+    @Override
+    default StringBuilder stringify(int depth, StringBuilder into)
+    {
+        if (isEmpty())
+        {
+            return into;
+        }
+        Task.super.stringify(depth, into);
+        for (Task child : this)
+        {
+            child.stringify(depth + 1, into);
+        }
+        return into;
+    }
+
+    /**
+     * Add a runnable to this set of tasks
+     *
+     * @param name A textual description of what the passed runnable will do,
+     * suitable for logging
+     * @param code The thing to run
+     * @return this
+     */
+    default TaskGroup add(String name, ThrowingRunnable code)
+    {
+        return add(new TaskImpl(name, code));
+    }
+
+    /**
+     * Add some code to run to this set of tasks, which may return a
+     * <code>ThrowingRunnable</code> which should be used to roll back whatever
+     * the code did, in the event that a subsequent task throws an exception or
+     * error.
+     * <p>
+     * In the event of rollback, the framework guarantees that the rollback code
+     * <b>will</b> run <i>regardless of whether previously run rollback code
+     * threw an exception</i>, unless the throwable thrown by a rollback or a
+     * task is neither an instance of <code>java.lang.Exception</code> nor
+     * <code>java.lang.Error</code>.
+     * </p>
+     *
+     * @param name A textual description of what the passed code will do,
+     * suitable for logging
+     * @param code The thing to run, which (optionally) returns a
+     * <code>ThrowingRunnable</code> that can undo
+     * @return this
+     */
+    default TaskGroup add(String name, ThrowingSupplier<ThrowingRunnable> code)
+    {
+        return add(new RollbackTaskImpl(name, code));
+    }
+
+    /**
+     * Creates a new child task group attached to this group. Note: When logging
+     * or using <code>toString()</code> on a <code>TaskGroup</code> a group only
+     * appears in the string representation if it contains non-empty children.
+     *
+     * @param name The name for the group
+     * @return A new task group
+     */
+    default TaskGroup group(String name)
+    {
+        TaskGroup result = new TaskGroupImpl(name);
+        add(result);
+        return result;
+    }
+
+    /**
+     * Creates a new child task group attached to this group and passes it to
+     * the passed consumer. Note: When logging or using <code>toString()</code>
+     * on a <code>TaskGroup</code> a group only appears in the string
+     * representation if it contains non-empty children.
+     *
+     * @param name The name for the group
+     * @param childConsumer A consumer which will add to the tasks
+     * @return this - the created group is accessible only via the consumer
+     */
+    default TaskGroup group(String name,
+            ThrowingConsumer<TaskGroup> childConsumer)
+    {
+        TaskGroup child = group(name);
+        childConsumer.toNonThrowing().accept(child);
+        return this;
+    }
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskGroupImpl.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskGroupImpl.java
@@ -1,0 +1,95 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.util.preconditions.Checks;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+/**
+ *
+ * @author Tim Boudreau
+ */
+final class TaskGroupImpl implements TaskGroup
+{
+    private final List<Task> children = new CopyOnWriteArrayList<>();
+    final String name;
+
+    TaskGroupImpl(String name)
+    {
+        this.name = Checks.notNull("name", name);
+    }
+
+    @Override
+    public Iterator<Task> iterator()
+    {
+        return Collections.unmodifiableList(children).iterator();
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        boolean result = children.isEmpty();
+        if (!result)
+        {
+            result = true;
+            for (Task t : children)
+            {
+                if (!t.isEmpty())
+                {
+                    result = false;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public TaskGroup add(Task task)
+    {
+        children.add(task);
+        return this;
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public void accept(Consumer<String> log, Rollback rollbacks) throws Exception
+    {
+        log.accept(name());
+        for (Task child : children)
+        {
+            child.accept(log, rollbacks);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return stringify();
+    }
+
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskImpl.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskImpl.java
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.function.throwing.ThrowingRunnable;
+import java.util.function.Consumer;
+
+import static com.mastfrog.util.preconditions.Checks.notNull;
+
+/**
+ * Implementation of Task.
+ *
+ * @author Tim Boudreau
+ */
+final class TaskImpl implements Task
+{
+    final String name;
+    final ThrowingRunnable run;
+
+    TaskImpl(String name, ThrowingRunnable run)
+    {
+        this.name = notNull("name", name);
+        this.run = notNull("run", run);
+    }
+
+    @Override
+    public void accept(Consumer<String> log, Rollback rb) throws Exception
+    {
+        log.accept(name);
+        run.run();
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public String toString()
+    {
+        return stringify();
+    }
+
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskSet.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/TaskSet.java
@@ -1,0 +1,76 @@
+package com.telenav.cactus.maven.task;
+
+import java.util.function.Consumer;
+
+/**
+ * A set of tasks which can be added to and run exactly once.
+ *
+ * @author Tim Boudreau
+ */
+public interface TaskSet extends TaskGroup
+{
+
+    /**
+     * Run any added tasks; in the case of failure, perform any added rollback
+     * tasks that were produced by running the tasks. Rollbacks run regardless
+     * of the failure of other rollbacks.
+     * <p>
+     * If an exception is thrown by any task, execution of the remaining tasks
+     * is aborted, and any rollback code produced by tasks is run in reverse
+     * task order.
+     * </p><p>
+     * If a rollback job throws an exception, that exception is attached to the
+     * exception that triggered the rollback.
+     * </p>
+     *
+     * @throws Exception if something goes wrong
+     */
+    void execute() throws Exception;
+
+    /**
+     * Create a new task set with a generic name for the root task and default
+     * logger.
+     *
+     * @return A task set
+     */
+    public static TaskSet newTaskSet()
+    {
+        return new Tasks();
+    }
+
+    /**
+     * Create a new task set with a generic name for the root task.
+     *
+     * @param logger A consumer which will be notified when a task is run or
+     * rolled back
+     * @return A task set
+     */
+    public static TaskSet newTaskSet(Consumer<String> logger)
+    {
+        return new Tasks(logger);
+    }
+
+    /**
+     * Create a new task set that uses the passed name for its root task name.
+     *
+     * @param name The loggable name of the root task
+     * @return A task set
+     */
+    public static TaskSet newTaskSet(String name)
+    {
+        return new Tasks(name);
+    }
+
+    /**
+     * Create a new task set that uses the passed name for its root task name.
+     *
+     * @param name The loggable name of the root task
+     * @param logger A consumer which will be notified when a task is run or
+     * rolled back
+     * @return A task set
+     */
+    public static TaskSet newTaskSet(String name, Consumer<String> logger)
+    {
+        return new Tasks(name, logger);
+    }
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/Tasks.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/task/Tasks.java
@@ -1,0 +1,182 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// © 2011-2022 Telenav, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.function.throwing.ThrowingConsumer;
+import com.mastfrog.function.throwing.ThrowingRunnable;
+import com.mastfrog.function.throwing.ThrowingSupplier;
+import com.telenav.cactus.maven.log.BuildLog;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.function.Consumer;
+
+import static com.mastfrog.util.preconditions.Checks.notNull;
+import static java.util.Collections.unmodifiableList;
+
+/**
+ * A structured set of tasks to run, with support for logging work as it
+ * happens, nested groups of related tasks that must run before any others,
+ * formatted string representation, and the ability for a task to provide some
+ * work to perform to roll back what it did if an error is encountered later.
+ *
+ * @author Tim Boudreau
+ */
+final class Tasks implements TaskSet
+{
+    private final List<Task> children = new CopyOnWriteArrayList<>();
+    private final Consumer<String> log;
+    private final String name;
+
+    Tasks()
+    {
+        this("root");
+    }
+
+    Tasks(String name)
+    {
+        this.name = name;
+        log = BuildLog.get().child("tasks");
+    }
+
+    Tasks(String name, Consumer<String> log)
+    {
+        this.name = name;
+        this.log = log;
+    }
+
+    Tasks(Consumer<String> log)
+    {
+        this("root", log);
+    }
+
+    @Override
+    public Iterator<Task> iterator()
+    {
+        return unmodifiableList(children).iterator();
+    }
+
+    @Override
+    public Tasks add(String name, ThrowingRunnable run)
+    {
+        children.add(new TaskImpl(notNull("name", name), notNull("run", run)));
+        return this;
+    }
+
+    @Override
+    public Tasks add(String name, ThrowingSupplier<ThrowingRunnable> run)
+    {
+        children.add(new RollbackTaskImpl(notNull("name", name), notNull("run",
+                run)));
+        return this;
+    }
+
+    @Override
+    public TaskGroup group(String name)
+    {
+        TaskGroup group = new TaskGroupImpl(name);
+        children.add(group);
+        return group;
+    }
+
+    @Override
+    public Tasks group(String name, ThrowingConsumer<TaskGroup> groupConsumer)
+    {
+        TaskGroup result = group(name);
+        groupConsumer.toNonThrowing().accept(result);
+        return this;
+    }
+
+    @Override
+    public void execute() throws Exception
+    {
+        try
+        {
+            Rollback rollback = new Rollback();
+            rollback.executeWithRollback(() ->
+            {
+                for (Task kid : children)
+                {
+                    log.accept(kid.name());
+                    kid.accept(log, rollback);
+                }
+            });
+        }
+        finally
+        {
+            children.clear();
+        }
+    }
+
+    @Override
+    public Tasks add(Task task)
+    {
+        children.add(notNull("task", task));
+        return this;
+    }
+
+    @Override
+    public void accept(Consumer<String> logger, Rollback rollbacks) throws Exception
+    {
+        for (Task t : children)
+        {
+            t.accept(logger, rollbacks);
+        }
+    }
+
+    @Override
+    public StringBuilder stringify(int depth, StringBuilder into)
+    {
+        return TaskSet.super.stringify(depth, into);
+    }
+
+    @Override
+    public String name()
+    {
+        return name;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        for (Task t : children)
+        {
+            t.stringify(sb);
+        }
+        return sb.toString();
+    }
+
+    public boolean isEmpty()
+    {
+        boolean result = children.isEmpty();
+        if (!result)
+        {
+            result = true;
+            for (Task t : children)
+            {
+                if (!t.isEmpty())
+                {
+                    result = false;
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/tree/ProjectTree.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/tree/ProjectTree.java
@@ -455,6 +455,10 @@ public class ProjectTree
     public Set<ProjectFamily> allProjectFamilies() {
         return withCache(ProjectTreeCache::allProjectFamilies);
     }
+    
+    public void invalidateBranches(GitCheckout co) {
+        withCache(cache -> cache.invalidateBranches(co));
+    }
 
     /**
      * Get a depth-first list of checkouts matching this scope, given the passed

--- a/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/tree/ProjectTreeCache.java
+++ b/cactus-maven-plugin/src/main/java/com/telenav/cactus/maven/tree/ProjectTreeCache.java
@@ -48,10 +48,13 @@ final class ProjectTreeCache
     {
         this.outer = outer;
     }
-    
-    public Set<ProjectFamily> allProjectFamilies() {
-        if (families.isEmpty()) {
-            allPoms().forEach(pom -> {
+
+    public Set<ProjectFamily> allProjectFamilies()
+    {
+        if (families.isEmpty())
+        {
+            allPoms().forEach(pom ->
+            {
                 families.add(ProjectFamily.familyOf(pom));
             });
         }
@@ -382,4 +385,9 @@ final class ProjectTreeCache
                 });
     }
 
+    Void invalidateBranches(GitCheckout co)
+    {
+        this.allBranches.remove(co);
+        return null;
+    }
 }

--- a/cactus-maven-plugin/src/test/java/com/telenav/cactus/maven/task/TasksTest.java
+++ b/cactus-maven-plugin/src/test/java/com/telenav/cactus/maven/task/TasksTest.java
@@ -1,0 +1,363 @@
+package com.telenav.cactus.maven.task;
+
+import com.mastfrog.function.throwing.ThrowingRunnable;
+import com.mastfrog.function.throwing.ThrowingSupplier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.mastfrog.util.preconditions.Exceptions.chuck;
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ *
+ * @author Tim Boudreau
+ */
+public class TasksTest
+{
+    private Tasks tasks;
+    private Set<String> executed;
+    private List<String> rolledBack;
+
+    @Test
+    public void testEmptyGroupsIsEmptyTasks()
+    {
+        assertTrue(tasks.isEmpty());
+        tasks.group("a");
+        tasks.group("b", grp ->
+        {
+            grp.group("c");
+            grp.group("d", d ->
+            {
+                d.group("e");
+            });
+        });
+        assertTrue(tasks.isEmpty());
+        assertEquals("", tasks.toString());
+    }
+
+    @Test
+    public void testSimpleRun() throws Exception
+    {
+        assertTrue(tasks.isEmpty());
+        addOne("a").addOne("b").addOne("c").addOne("d");
+        assertEquals(" * a\n"
+                + " * b\n"
+                + " * c\n"
+                + " * d", tasks.toString());
+        tasks.execute();
+        assertRan("a", "b", "c", "d");
+        assertTrue(tasks.isEmpty());
+    }
+
+    @Test
+    public void testNestedRun() throws Exception
+    {
+        assertTrue(tasks.isEmpty());
+        tasks.group("a", a ->
+        {
+            a.add("a1", oneRun("a1"));
+            a.add("a2", oneRun("a3"));
+            a.group("a3", a3 ->
+            {
+                a3.add("a3a", oneRun("a3a"));
+                a3.add("a3b", oneRun("a3b"));
+                a3.add("a3c", oneRun("a3c"));
+                a3.group("a3d", a3d ->
+                {
+                    a3d.add("a3d1", oneRun("a3d1"));
+                    a3d.add("a3d2", oneRun("a3d2"));
+                });
+            });
+        }).add("b", oneRun("b"))
+                .group("c", c ->
+                {
+                    c.add("c1", oneRun("c1"));
+                    c.group("c2", c2 ->
+                    {
+                        c2.add("c2a", oneRun("c2a"));
+                    });
+                })
+                .group("shouldBeAbsent1", grp ->
+                {
+                    grp.group("shouldBeAbsent2");
+                });
+
+        assertFalse(tasks.toString().contains("shouldBeAbsent1"),
+                () -> "Empty groups should not appear in string representation, but got " + tasks);
+        assertFalse(tasks.toString().contains("shouldBeAbsent2"),
+                () -> "Empty groups should not appear in string representation, but got " + tasks);
+
+        assertTrue(tasks.toString().contains("\n   * a1"),
+                () -> "Indentation is wrong? " + tasks);
+        assertTrue(tasks.toString().contains("\n       * a3d1"),
+                () -> "Indentation is wrong? " + tasks);
+
+        tasks.execute();
+
+        assertRan("a1", "a3c", "a3b", "a3", "b", "a3d1", "c2a", "a3d2", "a3a",
+                "c1");
+    }
+
+    @Test
+    public void testSimpleRollback() throws Exception
+    {
+        addOneRollback("a");
+        addOneRollback("b");
+        addOneRollback("c");
+        addOneRollback("d");
+        tasks.add("e", oneThrow("e", () -> new FailureOne()));
+        tasks.add("f", oneThrow("e", () -> new FailureTwo()));
+
+        FailureOne failure = expectThrown(FailureOne.class);
+        assertNotNull(failure);
+        assertNull(failure.getCause());
+        assertEquals(0, failure.getSuppressed().length);
+        assertRan("a", "b", "c", "d", "e");
+        assertDidNotRun("f");
+        assertRolledBack("a", "b", "c", "d");
+        assertNotRolledBack("e", "f");
+        assertRollBackOrder("d", "c", "b", "a");
+    }
+
+    @Test
+    public void testGroupRollback() throws Exception
+    {
+        addOneRollback("a");
+        addOneRollback("b");
+        tasks.group("group", grp ->
+        {
+            grp.add("c", oneRollback("c"));
+            grp.group("nestedGroup", ngrp ->
+            {
+                grp.add("d", oneRollback("d"));
+            });
+        });
+        tasks.add("e", oneThrow("e", () -> new FailureOne()));
+        tasks.add("f", oneThrow("e", () -> new FailureTwo()));
+
+        FailureOne failure = expectThrown(FailureOne.class);
+        assertNotNull(failure);
+        assertNull(failure.getCause());
+        assertEquals(0, failure.getSuppressed().length);
+        assertRan("a", "b", "c", "d", "e");
+        assertDidNotRun("f");
+        assertRolledBack("a", "b", "c", "d");
+        assertNotRolledBack("e", "f");
+        assertRollBackOrder("d", "c", "b", "a");
+    }
+
+    @Test
+    public void testRollbackRunsEvenWhenOtherRollbacksThrow() throws Exception
+    {
+        addOneRollback("a");
+        addOneRollback("b");
+        addOneRollbackThrow("c", () -> new FailureOne());
+        addOneRollback("d");
+        addOneRollback("e");
+        addOneRollbackThrow("f", () -> new FailureTwo());
+        addOneRollback("g");
+        TaskGroup h = tasks.group("h");
+        h.add("i", oneRollback("i"));
+        h.add("j", oneRollbackThrow("j", () -> new ErrorOne()));
+        addOne("k");
+        tasks.add("l", () ->
+        {
+            throw new ErrorTwo();
+        });
+
+        ErrorTwo thrown = expectThrown(ErrorTwo.class);
+        List<Class<?>> exceptionChain = unwind(thrown);
+
+        assertEquals(asList(ErrorTwo.class, ErrorOne.class, FailureTwo.class,
+                FailureOne.class),
+                exceptionChain,
+                "All thrown exceptions and errors should have been captured");
+
+        assertRan("a", "b", "c", "d", "e", "f", "g", "i", "j", "k");
+        assertRollBackOrder("i", "g", "e", "d", "b", "a");
+    }
+
+    @Test
+    public void testOtherThrowableBypasses() throws Exception
+    {
+        addOneRollback("a");
+        addOneRollback("b");
+        addOneRollback("c");
+        addOneRollback("d");
+        tasks.add("x", () ->
+        {
+            chuck(new OtherThrowable());
+        });
+        expectThrown(OtherThrowable.class);
+        assertRan("a", "b", "c", "d");
+        assertTrue(rolledBack.isEmpty(),
+                "Rollback should not have run for random throwable");
+    }
+
+    private <E extends Throwable> E expectThrown(Class<E> type)
+    {
+        try
+        {
+            tasks.execute();
+            throw new AssertionError("Nothing was thrown - expected "
+                    + type.getSimpleName());
+        }
+        catch (Throwable t)
+        {
+            if (type.isInstance(t))
+            {
+                return type.cast(t);
+            }
+            return chuck(t);
+        }
+    }
+
+    TasksTest addOne(String name)
+    {
+        tasks.add(name, oneRun(name));
+        return this;
+    }
+
+    TasksTest addOneRollback(String name)
+    {
+        tasks.add(name, oneRollback(name));
+        return this;
+    }
+
+    TasksTest addOneRollbackThrow(String name, Supplier<Throwable> thrown)
+    {
+        tasks.add(name, oneRollbackThrow(name, thrown));
+        return this;
+    }
+
+    private ThrowingRunnable oneRun(String s)
+    {
+        return () -> executed.add(s);
+    }
+
+    private ThrowingRunnable oneThrow(String name, Supplier<Throwable> thrower)
+    {
+        return () ->
+        {
+            executed.add(name);
+            chuck(thrower.get());
+        };
+    }
+
+    private ThrowingSupplier<ThrowingRunnable> oneRollbackThrow(String name,
+            Supplier<Throwable> thrower)
+    {
+        return () ->
+        {
+            executed.add(name);
+            return () -> chuck(thrower.get());
+        };
+    }
+
+    private ThrowingSupplier<ThrowingRunnable> oneRollback(String name)
+    {
+        return () ->
+        {
+            executed.add(name);
+            return ()
+                    -> rolledBack.add(name);
+        };
+    }
+
+    private void assertRan(String... prts)
+    {
+        assertEquals(new HashSet<>(asList(prts)), executed);
+    }
+
+    private void assertRolledBack(String... prts)
+    {
+        assertEquals(new HashSet<>(asList(prts)), new HashSet<>(rolledBack));
+    }
+
+    private void assertNotRolledBack(String... prts)
+    {
+        Set<String> rb = new HashSet<>(rolledBack);
+        Set<String> expected = new HashSet<>(asList(prts));
+        rb.retainAll(expected);
+        assertTrue(rb.isEmpty(), "Unexpected rollbacks: " + rb);
+    }
+
+    private void assertRollBackOrder(String... prts)
+    {
+        assertEquals(rolledBack, asList(prts));
+    }
+
+    private void assertDidNotRun(String... parts)
+    {
+        Set<String> set = new HashSet<>(asList(parts));
+        assertEquals(set.size(), parts.length, "Passed duplicates");
+        set.retainAll(executed);
+        assertEquals(0, set.size(),
+                "Some unexpected tasks were run: " + set);
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        tasks = new Tasks();
+        executed = new HashSet<>();
+        rolledBack = new ArrayList<>();
+    }
+
+    static List<Class<?>> unwind(Throwable thrown)
+    {
+        List<Class<?>> result = new ArrayList<>();
+        unwind(thrown, result);
+        return result;
+    }
+
+    static void unwind(Throwable thrown, List<Class<?>> into)
+    {
+        if (thrown == null)
+        {
+            return;
+        }
+        into.add(thrown.getClass());
+        Throwable[] supp = thrown.getSuppressed();
+        if (supp != null)
+        {
+            for (Throwable t : supp)
+            {
+                unwind(t, into);
+            }
+        }
+        unwind(thrown.getCause(), into);
+    }
+
+    static class FailureOne extends Exception
+    {
+
+    }
+
+    static class FailureTwo extends Exception
+    {
+
+    }
+
+    static class ErrorOne extends Error
+    {
+
+    }
+
+    static class ErrorTwo extends Error
+    {
+
+    }
+
+    static class OtherThrowable extends Throwable
+    {
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -168,6 +168,11 @@
 
             <dependency>
                 <groupId>com.mastfrog</groupId>
+                <artifactId>abstractions</artifactId>
+                <version>${mastfrog.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.mastfrog</groupId>
                 <artifactId>function</artifactId>
                 <version>${mastfrog.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,7 @@
         <!-- Java -->
 
         <java.version>11</java.version>
+        <jackson.version>2.13.3</jackson.version>
 
         <!-- Mastfrog -->
         <mastfrog.version>2.8.3</mastfrog.version>
@@ -95,7 +96,6 @@
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven.api.version>3.8.6</maven.api.version>
         <maven.javadoc.plugin.version>3.4.0</maven.javadoc.plugin.version>
-        <jackson.version>2.13.3</jackson.version>
 
         <slf4j.version>1.7.36</slf4j.version>
 
@@ -211,6 +211,11 @@
 
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
@@ -288,37 +293,6 @@
                         <phase>generate-sources</phase>
                     </execution>
                 </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-plugin-plugin</artifactId>
-                <configuration>
-                    <goalPrefix>cactus</goalPrefix>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>mojo-descriptor-compile-time</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-
-                    <execution>
-                        <id>mojo-descriptor</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>descriptor</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>generated-helpmojo</id>
-                        <goals>
-                            <goal>helpmojo</goal>
-                        </goals>
-                    </execution>
-                </executions>
-
             </plugin>
 
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <nexus-staging-maven-plugin.version>1.6.13</nexus-staging-maven-plugin.version>
         <maven.api.version>3.8.6</maven.api.version>
         <maven.javadoc.plugin.version>3.4.0</maven.javadoc.plugin.version>
+        <jackson.version>2.13.3</jackson.version>
 
         <slf4j.version>1.7.36</slf4j.version>
 
@@ -201,6 +202,19 @@
                 <version>${mastfrog.version}</version>
             </dependency>
 
+            <!-- JSON -->
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-annotations</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+
             <!-- Maven -->
 
             <dependency>
@@ -257,7 +271,7 @@
             <plugin>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>cactus-maven-plugin</artifactId>
-                <!-- This has to be the previous version or we 
+                <!-- This has to be the previous version or we
                 create a cycle in the dependency graph -->
                 <version>${cactus.previous.version}</version>
                 <executions>
@@ -284,7 +298,7 @@
                             <goal>descriptor</goal>
                         </goals>
                     </execution>
-                    
+
                     <execution>
                         <id>mojo-descriptor</id>
                         <phase>process-classes</phase>
@@ -301,11 +315,11 @@
                 </executions>
 
             </plugin>
-            
+
         </plugins>
 
         <pluginManagement>
-            
+
             <plugins>
 
                 <plugin>


### PR DESCRIPTION
Multi-Repo PR Creation

Ensures PR creation can succeed in all repositories before doing anything, and generates commits and pushes if needed; takes pains to ensure `gh` cannot go into interactive-mode and hang Maven


Creating Pull Requests In
-------------------------

  * cactus feature/rigorous-pull-requests -> develop


Metadata
--------

  * Invoked on com.telenav.cactus:cactus:1.5.23
  * SearchNonce: Xj0QcCMV1G-rgh6ym

##### Provenance

Generated by cactus: *cactus-maven-plugin* version _1.5.23_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-08-12T00:06:23Z
  * Plugin-Build:	tungsten beachball
  * Plugin-Date:	2022.08.11
  * Plugin-Commit:	b4a9a70a50e5df6d6edb4de0adbc8e2b71132bde
  * Plugin-Repo-Clean:	false
