### PR TITLE
🔨 move build failure test to last step since it was not being trigger…

### DIFF
--- a/.github/workflows/build-branch.yml
+++ b/.github/workflows/build-branch.yml
@@ -39,10 +39,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build Failed
-        if: failure()
-        run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=build-failures --data-urlencode content="Build of $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME) failed"
-
       - name: Building
         run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=builds --data-urlencode content="Building $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME)"
 
@@ -95,3 +91,7 @@ jobs:
 
       - name: Done Building
         run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=builds --data-urlencode content="Done building $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME)"
+
+      - name: Build Failed
+        if: failure()
+        run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=build-failures --data-urlencode content="Build of $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME) failed"

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -35,10 +35,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build Failed
-        if: failure()
-        run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=build-failures --data-urlencode content="Build of $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME) failed"
-
       - name: Building
         run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=builds --data-urlencode content="Building $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME)"
 
@@ -94,3 +90,7 @@ jobs:
 
       - name: Done Building
         run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=builds --data-urlencode content="Done building $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME)"
+
+      - name: Build Failed
+        if: failure()
+        run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=build-failures --data-urlencode content="Build of $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME) failed"

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -35,10 +35,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Build Failed
-        if: failure()
-        run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=build-failures --data-urlencode content="Build of $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME) failed"
-
       - name: Building
         run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=builds --data-urlencode content="Building $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME)"
 
@@ -94,3 +90,7 @@ jobs:
 
       - name: Done Building
         run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=builds --data-urlencode content="Done building $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME)"
+
+      - name: Build Failed
+        if: failure()
+        run: curl -X POST https://telenav.zulipchat.com/api/v1/messages -u message-bot@telenav.zulipchat.com:0NKgz2EcIM8Bs2wpEmh67TOApRVk3sF4 --data-urlencode type=stream --data-urlencode to=github-notifications --data-urlencode topic=build-failures --data-urlencode content="Build of $GITHUB_REPOSITORY ($GITHUB_EVENT_NAME $GITHUB_REF_NAME) failed"


### PR DESCRIPTION
…ed as expected when at the top (it doesn't work the same way as `always()`)