### PR TITLE
"'Detect null returned from a maven run and give better diagnostics'"

### DIFF
--- a/cactus-tests/src/main/java/com/telenav/cactus/test/project/WrappedProjectImpl.java
+++ b/cactus-tests/src/main/java/com/telenav/cactus/test/project/WrappedProjectImpl.java
@@ -29,6 +29,8 @@ import com.telenav.cactus.test.project.generator.ProjectsGenerator;
 import com.telenav.cactus.test.project.starwars.StarWars;
 import java.nio.file.Path;
 
+import static java.lang.System.currentTimeMillis;
+
 /**
  * Wrapper for a non-pom, java source project.
  *
@@ -82,8 +84,16 @@ final class WrappedProjectImpl implements ProjectWrapper
     @Override
     public boolean runMaven(String... args)
     {
+        long then = currentTimeMillis();
         MavenCommand cmd = new MavenCommand(path(), args);
-        return cmd.run().awaitQuietly(StarWars.TIMEOUT);
+        Boolean result = cmd.run().awaitQuietly();
+        if (result == null)
+        {
+            throw new IllegalStateException(
+                    "Null result from " + cmd + " - probable timeout? "
+                    + (currentTimeMillis() - then) + " ms execution time.");
+        }
+        return result;
     }
 
     @Override


### PR DESCRIPTION
"'Detect null returned from a maven run and give better diagnostics'



Creating Pull Requests In
-------------------------

  * cactus tests-maven-null-detect -> develop


Metadata
--------

  * Invoked on com.telenav.cactus:cactus-tests:1.5.24
  * SearchNonce: VHG8mUzIoT-rgxxf6

##### Provenance

Generated by cactus: *cactus-maven-plugin* version _1.5.24_.

  * Mojo:		GitPullRequestMojo
  * Generation-Time:	2022-08-21T00:59:31Z
  * Plugin-Build:	tungsten bobblehead
  * Plugin-Date:	2022.08.20
  * Plugin-Commit:	b1847904768100376427d20ac0a015259429b87c
  * Plugin-Repo-Clean:	false
"